### PR TITLE
Add CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+      - staging
+    paths-ignore:
+      - "doc/**"
+
+name: Continuous Integration
+
+jobs:
+  lint:
+    name: Run linters
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: 'yarn install'
+
+      - name: Lint Source Code
+        run: |
+          yarn lint --no-fix
+
+  lint-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cschleiden/actions-linter@v1
+        with:
+          workflows: '[".github/workflows/*.yaml", ".github/workflows/*.yml"]'
+
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: 'yarn install'
+
+      - name: Run unit tests
+        run: |
+          echo "::warning file=package.json,title=Unit tests are broken::The 'yarn test:unit' command is currently broken"
+          # yarn test:unit
+
+  test-server:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: "postgres:13"
+        env:
+          POSTGRES_DB: arpa-reporter-test
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test-password
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: 'yarn install'
+
+      - name: Run server tests
+        run: |
+          yarn knex migrate:latest
+          yarn test:server
+        env:
+          POSTGRES_URL: 'postgres://test:test-password@localhost:5432/arpa-reporter-test'
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: 'yarn install'
+
+      - name: Build the production bundle
+        run: |
+          yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ name: Continuous Integration
 
 jobs:
   lint:
-    name: Run linters
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           POSTGRES_DB: 'server_test'
           POSTGRES_USER: 'test'
           POSTGRES_PASSWORD: 'password'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
         ports:
           - 5432:5432
         # Set health checks to wait until postgres has started

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           # and password. The config here must match.
           # (See tests/*/mocha_wrapper.sh)
           POSTGRES_DB: 'server_test'
-          POSTGRES_USER: 'root'
+          POSTGRES_USER: 'test'
           POSTGRES_PASSWORD: ''
         ports:
           - 5432:5432

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         env:
           # FIXME: this doesn't actually matter since the tests hardcode a
           # database name and user/password.
-          POSTGRES_URL: 'postgres://test:test-password@localhost:5432/arpa-reporter-test'
+          POSTGRES_URL: 'postgres://test:password@localhost:5432/server_test'
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           # (See tests/*/mocha_wrapper.sh)
           POSTGRES_DB: 'server_test'
           POSTGRES_USER: 'test'
-          POSTGRES_PASSWORD: ''
+          POSTGRES_PASSWORD: 'password'
         ports:
           - 5432:5432
         # Set health checks to wait until postgres has started

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,12 @@ jobs:
       postgres:
         image: "postgres:13"
         env:
-          POSTGRES_DB: arpa-reporter-test
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test-password
+          # FIXME: the test scripts currently hardcode a database name, user,
+          # and password. The config here must match.
+          # (See tests/*/mocha_wrapper.sh)
+          POSTGRES_DB: 'server_test'
+          POSTGRES_USER: 'root'
+          POSTGRES_PASSWORD: ''
         ports:
           - 5432:5432
         # Set health checks to wait until postgres has started
@@ -91,6 +94,8 @@ jobs:
           yarn knex migrate:latest
           yarn test:server
         env:
+          # FIXME: this doesn't actually matter since the tests hardcode a
+          # database name and user/password.
           POSTGRES_URL: 'postgres://test:test-password@localhost:5432/arpa-reporter-test'
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Run server tests
         run: |
+          # The .env file needs to be present; the example file is good enough.
+          cp .env.example .env
           yarn knex migrate:latest
           yarn test:server
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           # and password. The config here must match.
           # (See tests/*/mocha_wrapper.sh)
           POSTGRES_DB: 'server_test'
-          POSTGRES_USER: 'test'
+          POSTGRES_USER: 'postgres'
           POSTGRES_PASSWORD: 'password'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
         ports:
@@ -97,7 +97,7 @@ jobs:
         env:
           # FIXME: this doesn't actually matter since the tests hardcode a
           # database name and user/password.
-          POSTGRES_URL: 'postgres://test:password@localhost:5432/server_test'
+          POSTGRES_URL: 'postgres://postgres:password@localhost:5432/server_test'
 
   build:
     runs-on: ubuntu-latest

--- a/src/components/AgencyHome.vue
+++ b/src/components/AgencyHome.vue
@@ -24,7 +24,7 @@
 <script>
 import UploadHistory from '../components/UploadHistory'
 import moment from 'moment'
-import _ from 'lodash'
+import _ from "lodash"
 export default {
   name: 'Home',
   components: {

--- a/src/components/AgencyHome.vue
+++ b/src/components/AgencyHome.vue
@@ -24,7 +24,7 @@
 <script>
 import UploadHistory from '../components/UploadHistory'
 import moment from 'moment'
-import _ from "lodash"
+import _ from 'lodash'
 export default {
   name: 'Home',
   components: {

--- a/tests/server/mocha_wrapper.sh
+++ b/tests/server/mocha_wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export POSTGRES_URL="postgres://localhost/server_test"
+export POSTGRES_URL="postgres://postgres@localhost/server_test"
 export UPLOAD_DIRECTORY=`dirname $0`/mocha_uploads
 export TREASURY_DIRECTORY=`dirname $0`/mocha_uploads/treasury
 

--- a/tests/server/mocha_wrapper.sh
+++ b/tests/server/mocha_wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export POSTGRES_URL="postgres://postgres@localhost/server_test"
+export POSTGRES_URL="postgres://localhost/server_test"
 export UPLOAD_DIRECTORY=`dirname $0`/mocha_uploads
 export TREASURY_DIRECTORY=`dirname $0`/mocha_uploads/treasury
 

--- a/tests/server/reset-db.sh
+++ b/tests/server/reset-db.sh
@@ -30,7 +30,8 @@ else
   psql -h localhost -U postgres -w postgres -c "CREATE DATABASE $dbname"
 fi
 
-yarn knex migrate:latest
-yarn knex --knexfile tests/server/knexfile.js seed:run
-
+echo "Running migrations with POSTGRES_URL: '${POSTGRES_URL}'"
+yarn knex --debug migrate:latest
+yarn knex --debug --knexfile tests/server/knexfile.js seed:run
+echo "Done Migrating"
 

--- a/tests/server/reset-db.sh
+++ b/tests/server/reset-db.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "Running migrations with POSTGRES_URL: '${POSTGRES_URL}'"
-yarn knex --debug migrate:latest
-yarn knex --debug --knexfile tests/server/knexfile.js seed:run
+yarn knex migrate:latest
+yarn knex --knexfile tests/server/knexfile.js seed:run
 echo "Done Migrating"
 

--- a/tests/server/reset-db.sh
+++ b/tests/server/reset-db.sh
@@ -31,8 +31,5 @@ else
   psql -h localhost -U postgres -w postgres -c "CREATE DATABASE $dbname"
 fi
 
-echo "Running migrations with POSTGRES_URL: '${POSTGRES_URL}'"
 yarn knex migrate:latest
 yarn knex --knexfile tests/server/knexfile.js seed:run
-echo "Done Migrating"
-

--- a/tests/server/reset-db.sh
+++ b/tests/server/reset-db.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 # The actual directory of this file.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/tests/server/reset-dbx.sh
+++ b/tests/server/reset-dbx.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 # The actual directory of this file.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
This adds a continuous integration workflow that runs linters and tests on pull requests (and on pushes to `main` and `staging`) and reports the results as status checks. It should help make obvious that a PR is not safe before clicking the merge so we don’t have failed deploys or need things like #74 to quickly fix a bad merge.