### PR TITLE
Limit Dependabot pull requests to lockfile changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     schedule:
       interval: "daily"
     target-branch: staging
+    # Don't automatically suggest version updates that conflict with the
+    # package.json specification. This greatly reduces the likeihood that a
+    # dependabot update will break anything.
+    # When the package.json needs to be updated for security purposes, Github
+    # will alert us via a "security advisory" instead.
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
I merged all open dependabot changes a week ago, but immediately there was a new backlog to resolve.  In addition, several of the new dependencies introduced breaking changes that needed to be resolved by hand.

None of these version updates address meaningful security concerns, so I propose tweaking the dependabot configuration such that it respects the semver declarations in this project's `package.json`.

e.g. After this config change, if we declare a dependency on `"vue": "^2.6.14"`, dependabot will alert us to future minor versions or patches (e.g. `2.7.0` or `2.6.15`), but will not prompt us to upgrade across a major version (`3.2.31`).

My theory is that this will make it much easier for us to merge security patches and bug fixes in a timely fashion.