### PR TITLE
Fix hot reload firefox

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,11 +1,10 @@
 module.exports = {
   devServer: {
-    proxy: 'http://localhost:3000',
-    client: {
-      // Set the websocket path to sockjs-node so that vue-cli-service knows
-      // not to proxy the request.
-      // https://github.com/vuejs/vue-cli/blob/master/packages/%40vue/cli-service/lib/util/prepareProxy.js#L53
-      webSocketURL: { pathname: '/sockjs-node' }
+    proxy: {
+      // proxy requests whose paths match the pattern below to express
+      '/api': {
+        target: 'http://localhost:3000'
+      }
     }
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,11 @@
-
 module.exports = {
   devServer: {
-    proxy: 'http://localhost:3000'
+    proxy: 'http://localhost:3000',
+    client: {
+      // Set the websocket path to sockjs-node so that vue-cli-service knows
+      // not to proxy the request.
+      // https://github.com/vuejs/vue-cli/blob/master/packages/%40vue/cli-service/lib/util/prepareProxy.js#L53
+      webSocketURL: { pathname: '/sockjs-node' }
+    }
   }
 }


### PR DESCRIPTION
I think we can get hot reloading and Firefox support together after all!

It seems like this line in vue-cli-service is to blame:

https://github.com/vuejs/vue-cli/blob/master/packages/%40vue/cli-service/lib/util/prepareProxy.js#L53