### PR TITLE
Improve date input ergonomics

### DIFF
--- a/src/helpers/form-helpers.js
+++ b/src/helpers/form-helpers.js
@@ -78,7 +78,7 @@ export function validate (columns, record) {
         }
       }
       if (value && column.date) {
-        const d = moment(value, 'MM/DD/YYYY')
+        const d = moment(value)
         if (!d.isValid()) {
           validationMessages.push(
             makeValidationMessage(column, 'must be a valid date')

--- a/src/views/ReportingPeriod.vue
+++ b/src/views/ReportingPeriod.vue
@@ -84,7 +84,7 @@ export default {
       this.dateFields.forEach(f => {
         const v = updatedReportingPeriod[f]
         if (v) {
-          updatedReportingPeriod[f] = moment(v, 'MM/DD/YYYY').utc().format('YYYY-MM-DD')
+          updatedReportingPeriod[f] = moment(v).utc().format('YYYY-MM-DD')
         }
       })
       return this.$store


### PR DESCRIPTION
For some reason we constrain date inputs to an exact format, MM/DD/YYYY.  We don't specify that anywhere, so it was a bit frustrating for me to use the first time I tried to create a new reporting period.

We're already using moment.js to parse the input value, so I don't see any reason we shouldn't support anything moment can parse.

![image](https://user-images.githubusercontent.com/11449340/155903501-ca9d5558-5537-493a-9613-131319e317cd.png)
