### PR TITLE
Fix: Update button should reference "Reporting Period" instead of "ReportingPeriod"

### DIFF
--- a/src/views/ReportingPeriod.vue
+++ b/src/views/ReportingPeriod.vue
@@ -6,7 +6,7 @@
     </div>
     <div v-else>
       <DocumentForm
-        type="ReportingPeriod"
+        type="Reporting Period"
         :columns="fields"
         :record="editReportingPeriod"
         :id="editReportingPeriod.id"


### PR DESCRIPTION
Reading through the DocumentForm component it doesn't appear that this type key is used for anything other than labels in the form.  It should be safe to update to a human-friendly name.

Fixes #124