### PR TITLE
Enable some typechecking features in VS Code

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "checkJs": true
+  }
+}


### PR DESCRIPTION
This change is completely optional!

Migrating everything to TypeScript is probably more work than it's worth at this point, but I found that I could at least convince VS Code to give me some type hints and feedback in the editor by setting this configuration value in `jsconfig.json`.

The main downside here is that — since you can't actually write type annotations in .js files — you'll see some type errors that cannot be resolved.