### PR TITLE
Dependabot: ignore dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     # When the package.json needs to be updated for security purposes, Github
     # will alert us via a "security advisory" instead.
     versioning-strategy: lockfile-only
+    # We want to specifically highlight updates to dependencies that are
+    # customer facing.
+    allow:
+      - dependency-type: production


### PR DESCRIPTION
Keep dependabot notifications and updates focused on user-facing code.

One of the most common "security alerts" identified in development dependencies is "potential denial of service due to slow regular expressions".  We don't want to miss actual user facing security issues because they are drowned in notifications about slow CLI tools.

https://overreacted.io/npm-audit-broken-by-design/

Edit: see an actual example of this alert in our repository [here](https://github.com/usdigitalresponse/arpa-reporter/security/dependabot/6)!