### PR TITLE
Move vue/cli and eslint deps to "devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "initRender": "./scripts/initRender.mjs"
   },
   "dependencies": {
-    "@vue/cli": "^4.5.13",
     "aws-sdk": "^2.963.0",
     "body-parser": "^1.19.0",
     "connect-history-api-fallback": "^1.6.0",
@@ -33,7 +32,6 @@
     "core-js": "^3.21.1",
     "date-fns": "^2.23.0",
     "dotenv": "^16.0.0",
-    "eslint-config-standard": "^16.0.3",
     "express": "^4.17.3",
     "fs-extra": "^10.0.1",
     "knex": "^1.0.4",
@@ -46,7 +44,6 @@
     "nodemailer": "^6.6.3",
     "numeral": "^2.0.6",
     "pg": "^8.7.1",
-    "standard": "^16.0.3",
     "uuid": "^8.3.2",
     "vue": "^2.6.13",
     "vue-router": "^3.5.2",
@@ -54,6 +51,7 @@
     "xlsx": "^0.18.4"
   },
   "devDependencies": {
+    "@vue/cli": "^4.5.13",
     "@vue/cli-plugin-babel": "~5.0.4",
     "@vue/cli-plugin-eslint": "~5.0.1",
     "@vue/cli-plugin-router": "~5.0.1",
@@ -68,6 +66,7 @@
     "chalk": "^5.0.1",
     "concurrently": "7.0.0",
     "eslint": "^7.12.1",
+    "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
@@ -77,6 +76,7 @@
     "mocha": "^9.2.1",
     "nodemon": "2.0.15",
     "prettier": "2.6.1",
+    "standard": "^16.0.3",
     "vue-template-compiler": "^2.6.11",
     "webpack": "5.68.0"
   }


### PR DESCRIPTION
Declares vue CLI and eslint dependencies as devDependenices.

This is useful because auditing tools treat these categories differently.

before:

![image](https://user-images.githubusercontent.com/11449340/163504393-ecd7ca49-c966-43d7-939e-0605ca0643b1.png)

after:

![image](https://user-images.githubusercontent.com/11449340/163504414-b41c1f63-6ffc-4f96-8a76-4820f9391cef.png)
