### PR TITLE
Create exports zip file in-memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "initRender": "./scripts/initRender.mjs"
   },
   "dependencies": {
+    "adm-zip": "0.5.9",
     "aws-sdk": "^2.963.0",
     "body-parser": "^1.19.0",
     "connect-history-api-fallback": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "vue": "^2.6.13",
     "vue-router": "^3.5.2",
     "vuex": "^3.6.2",
-    "xlsx": "^0.18.4",
-    "zip-local": "^0.3.5"
+    "xlsx": "^0.18.4"
   },
   "devDependencies": {
     "@vue/cli": "^4.5.13",

--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -102,9 +102,7 @@ async function generateSubRecipient (periodId) {
   return loadTemplate('subawardBulkUpload')
 }
 
-async function generateReport(periodId) {
-  console.log('generateReport called', performance.now())
-
+async function generateReport (periodId) {
   // generate every csv file for the report
   const csvObjects = [
     { name: 'project18_229233BulkUploads', func: generateProject18 },

--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -132,8 +132,6 @@ async function generateReport (periodId) {
     { name: 'subRecipientBulkUpload', func: generateSubRecipient }
   ]
 
-  console.log('csvFiles generated', performance.now())
-
   const zip = new AdmZip()
 
   // compute the CSV data for each file, and write it into the zip container

--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -1,8 +1,7 @@
-
 const path = require('path')
-const { mkdir, rmdir, writeFile, readdir, readFile } = require('fs/promises')
+const { readdir, readFile } = require('fs/promises')
 const moment = require('moment')
-const zipper = require('zip-local')
+const AdmZip = require('adm-zip')
 const XLSX = require('xlsx')
 
 const { applicationSettings } = require('../db/settings')
@@ -103,17 +102,11 @@ async function generateSubRecipient (periodId) {
   return loadTemplate('subawardBulkUpload')
 }
 
-async function generateReport (periodId) {
-  // create a directory for the report
-  const dirName = path.join(
-    ARPA_REPORTS_DIR,
-    periodId.toString(),
-    (await generateReportName(periodId))
-  )
-  await mkdir(dirName, { recursive: true })
+async function generateReport(periodId) {
+  console.log('generateReport called', performance.now())
 
   // generate every csv file for the report
-  const csvFiles = [
+  const csvObjects = [
     { name: 'project18_229233BulkUploads', func: generateProject18 },
     { name: 'project19_234BulkUploads', func: generateProject19 },
     { name: 'project2128BulkUploads', func: generateProject2128 },
@@ -125,42 +118,53 @@ async function generateReport (periodId) {
     { name: 'project51518BulkUpload', func: generateProject51518 },
     { name: 'project519521BulkUpload', func: generateProject519521 },
     { name: 'projectBaselineBulkUpload', func: generateProjectBaseline },
-    { name: 'expendituresGT50000BulkUpload', func: generateExpendituresGT50000 },
-    { name: 'expendituresLT50000BulkUpload', func: generateExpendituresLT50000 },
-    { name: 'paymentsIndividualsLT50000BulkUpload', func: generatePaymentsIndividualsLT50000 },
+    {
+      name: 'expendituresGT50000BulkUpload',
+      func: generateExpendituresGT50000
+    },
+    {
+      name: 'expendituresLT50000BulkUpload',
+      func: generateExpendituresLT50000
+    },
+    {
+      name: 'paymentsIndividualsLT50000BulkUpload',
+      func: generatePaymentsIndividualsLT50000
+    },
     { name: 'subawardBulkUpload', func: generateSubaward },
     { name: 'subRecipientBulkUpload', func: generateSubRecipient }
   ]
 
-  // compute the CSV data for each file, and write it to disk
-  await Promise.all(csvFiles.map(csvFile => {
-    return csvFile.func(periodId)
-      .then(csvData => {
-        if (!Array.isArray(csvData)) {
-          console.dir(csvFile)
-          console.dir(csvData)
-          throw new Error(`CSV Data from ${csvFile.name} was not an array!`)
-        }
+  console.log('csvFiles generated', performance.now())
 
-        const sheet = XLSX.utils.aoa_to_sheet(csvData)
-        const csv = XLSX.utils.sheet_to_csv(sheet)
-        return writeFile(path.join(dirName, `${csvFile.name}.csv`), csv)
-      })
-  }))
-    .catch((err) => {
-      rmdir(dirName, { recursive: true })
-      throw err
-    })
+  const zip = new AdmZip()
 
-  // now we generate a zip file
-  const zipfileName = dirName + '.zip'
-  const zipfile = zipper.sync.zip(dirName)
-  zipfile.compress().save(zipfileName)
+  // compute the CSV data for each file, and write it into the zip container
+  const csvPromises = csvObjects.map(async ({ name, func }) => {
+    const csvData = await func(periodId)
+
+    if (!Array.isArray(csvData)) {
+      console.dir({ name, func })
+      console.dir(csvData)
+      throw new Error(`CSV Data from ${name} was not an array!`)
+    }
+
+    const sheet = XLSX.utils.aoa_to_sheet(csvData)
+    const csvString = XLSX.utils.sheet_to_csv(sheet)
+    const buffer = Buffer.from('\ufeff' + csvString, 'utf8')
+    zip.addFile(name + '.csv', buffer)
+  })
+
+  const reportNamePromise = generateReportName(periodId)
+
+  const [reportName] = await Promise.all([
+    reportNamePromise,
+    ...csvPromises
+  ])
 
   // return the correct format
   return {
-    filename: path.basename(zipfileName),
-    content: (await readFile(zipfileName))
+    filename: reportName + '.zip',
+    content: zip.toBuffer()
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2910,11 +2910,6 @@ async-retry@^1.2.1:
   dependencies:
     retry "0.13.1"
 
-async@^1.4.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
-
 async@^2.6.2:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
@@ -7577,13 +7572,6 @@ jsprim@^1.2.2:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
 
-jszip@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-2.6.1.tgz#b88f3a7b2e67a2a048152982c7a3756d9c4828f0"
-  integrity sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=
-  dependencies:
-    pako "~1.0.2"
-
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -9071,11 +9059,6 @@ packet-reader@1.0.0:
   resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
   integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
 
-pako@~1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
-
 param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
@@ -9847,11 +9830,6 @@ pupa@^2.1.1:
   integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
   dependencies:
     escape-goat "^2.0.0"
-
-q@^1.4.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
 qs@6.10.3:
   version "6.10.3"
@@ -12546,13 +12524,3 @@ zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
-
-zip-local@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/zip-local/-/zip-local-0.3.5.tgz#566c099d0903df1f6bbdd5c060bd62a96a7ad10a"
-  integrity sha512-GRV3D5TJY+/PqyeRm5CYBs7xVrKTKzljBoEXvocZu0HJ7tPEcgpSOYa2zFIsCZWgKWMuc4U3yMFgFkERGFIB9w==
-  dependencies:
-    async "^1.4.2"
-    graceful-fs "^4.1.3"
-    jszip "^2.6.1"
-    q "^1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2420,6 +2420,11 @@ adler-32@~1.3.0:
   dependencies:
     printj "~1.2.2"
 
+adm-zip@0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
+  integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"


### PR DESCRIPTION
[OPTIONAL]

This change uses adm-zip (a js implementation of the zip algorithm) to generate our exported zip file without having to interact with the disk.

I suspected this would meaningfully improve our export times, but I was not able to measure a meaningful performance change.  It's possible that this will change with larger quantities of real data.

The remaining advantages of this approach are:
- we never have to worry about accumulating intermediate export files on disk, and we don't have to think about cleaning those files up
- it fixes two [security](https://github.com/usdigitalresponse/arpa-reporter/security/dependabot/26) [vulnerabilities](https://github.com/usdigitalresponse/arpa-reporter/security/dependabot/27) that dependabot is complaining about.

🤷  I don't think this is as compelling as #220 yet, but I figured I might as well push the change and talk it through.