### PR TITLE
UPLOAD_DIR should be stable across restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,6 @@ VALIDATION_TEMPLATE="validation-template.xlsx"
 # Agency input spreadsheet archives
 # This is /var/data/uploads in the states' deployed instances
 UPLOAD_DIRECTORY="./uploads"
-DATA_DIR="./datadir"
 
 COOKIE_SECRET=anystringwilldo
 INITIAL_ADMIN_EMAILS="admin1@example.com, admin2@example.com"

--- a/src/server/environment.js
+++ b/src/server/environment.js
@@ -1,17 +1,9 @@
 
-const { tmpdir } = require('os')
-const { mkdtempSync } = require('fs')
 const { join, resolve } = require('path')
-
-function tempDataDir () {
-  return mkdtempSync(join(tmpdir(), 'arpa-data-'))
-}
 
 const VERBOSE = Boolean(process.env.VERBOSE)
 
-const DATA_DIR = resolve(process.env.DATA_DIR || tempDataDir())
-const UPLOAD_DIR = join(DATA_DIR, 'uploads')
-const ARPA_REPORTS_DIR = join(DATA_DIR, 'arpa_reports')
+const UPLOAD_DIR = resolve(process.env.UPLOAD_DIRECTORY)
 
 const SRC_DIR = resolve(join(__dirname, '..'))
 const SERVER_DATA_DIR = join(SRC_DIR, 'server', 'data')
@@ -19,9 +11,7 @@ const SERVER_DATA_DIR = join(SRC_DIR, 'server', 'data')
 const EMPTY_TEMPLATE_NAME = 'ARPA SFRF Reporting Workbook v20220419.xlsm'
 
 module.exports = {
-  DATA_DIR,
   UPLOAD_DIR,
-  ARPA_REPORTS_DIR,
   SRC_DIR,
   SERVER_DATA_DIR,
   EMPTY_TEMPLATE_NAME,


### PR DESCRIPTION
@igor47 sorry, I didn't catch this in the initial PR.

Can you comment on your thinking when introducing this tmpdir approach for managing filesystem data?  I'm worried that using a randomly generated path in a path that the OS might clean up on some schedule isn't well-suited to the use case of persisting uploads.

At a minimum, doesn't this mean that redeploying the server will break references to previous uploads?