### PR TITLE
Display a loading spinner while waiting for treasury export!

### DIFF
--- a/src/components/GrantsOfficeHome.vue
+++ b/src/components/GrantsOfficeHome.vue
@@ -8,8 +8,8 @@
         This reporting period is closed.
       </div>
       <div class="col-3" v-show="viewingCurrentPeriod">
-        <a href="/api/audit_report" class="btn btn-primary"
-          >Download Audit Report</a
+        <a href="/api/audit_report" class="btn btn-primary disabled"
+          >Download Audit Report 🚧</a
         >
       </div>
       <div class="col-3" v-show="viewingCurrentPeriod">

--- a/src/components/GrantsOfficeHome.vue
+++ b/src/components/GrantsOfficeHome.vue
@@ -2,7 +2,22 @@
   <div>
     <div class="row buttons mt-5">
       <div class="col-3">
-        <a :href="downloadUrl()" class="btn btn-primary">Download Treasury Report</a>
+        <a
+          :href="downloadUrl()"
+          class="btn btn-primary"
+          :class="{ disabled: isLoading }"
+          @click="setLoadingState"
+          download
+        >
+          <span
+            v-if="isLoading"
+            class="spinner-border spinner-border-sm"
+            role="status"
+            aria-hidden="true"
+          ></span>
+          <span v-if="isLoading"> Loading...</span>
+          <span v-else> Download Treasury Report</span>
+        </a>
       </div>
       <div class="closed" v-show="isClosed">
         This reporting period is closed.
@@ -46,6 +61,13 @@ export default {
   components: {
     UploadHistory
   },
+  mounted () {
+    window.addEventListener('focus', this.clearLoadingState.bind(this))
+  },
+  destroyed () {
+    window.addEventListener('focus', this.clearLoadingState.bind(this))
+  },
+
   computed: {
     viewingCurrentPeriod () {
       return this.$store.getters.viewPeriodIsCurrent
@@ -61,13 +83,22 @@ export default {
       return period ? `/api/reporting_periods/${period.id}/template` : null
     }
   },
-  watch: {
+  data () {
+    return {
+      isLoading: false
+    }
   },
   methods: {
     titleize,
     downloadUrl () {
       const periodId = this.$store.getters.viewPeriod.id || 0
       return `/api/exports?period_id=${periodId}`
+    },
+    clearLoadingState () {
+      this.isLoading = false
+    },
+    setLoadingState () {
+      this.isLoading = true
     },
     documentCount (tableName) {
       if (tableName === 'subrecipient') {


### PR DESCRIPTION
Shows a loading spinner and disables the treasury report download button while waiting for download.

Note that the algorithm for deciding when to consider the download complete is not great.  It turns out that browsers don't actually report any feedback when a download link has been resolved.  I found some crazy workarounds involving setting a cookie with the download response, but the effort to support that seems far beyond the value of the extra precision!

https://stackoverflow.com/questions/1106377/detect-when-a-browser-receives-a-file-download

![Screen Shot 2022-05-21 at 11 32 11 pm](https://user-images.githubusercontent.com/11449340/169682308-33058c53-f276-45e6-b896-67f43efdc71e.png)
