### PR TITLE
Display a loading spinner while waiting for treasury export! (v2)

### DIFF
--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -23,7 +23,8 @@ export default {
   props: {
     href: String,
     customClass: String,
-    classes: Object
+    classes: Object,
+    disabled: Boolean
   },
   mounted () {
     window.addEventListener('focus', this.clearLoadingState)
@@ -40,10 +41,7 @@ export default {
     computedClasses () {
       return {
         ...this.classes,
-
-        // override parent disabled class if in loading state
-        // disabled: this?.classes?.disabled || this.isLoading
-        disabled: this.isLoading
+        disabled: this.disabled || this.isLoading
       }
     }
   },

--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -30,7 +30,7 @@ export default {
     window.addEventListener('focus', this.clearLoadingState)
   },
   destroyed () {
-    window.addEventListener('focus', this.clearLoadingState)
+    window.removeEventListener('focus', this.clearLoadingState)
   },
   data () {
     return {

--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -27,6 +27,12 @@ export default {
     disabled: Boolean
   },
   mounted () {
+    // Browsers don't report feedback when a link with the download attribute
+    // has been resolved.  Instead of doing something heavy-handed to work
+    // around this, we just assume that loading has resolved once the window
+    // regains focus.
+    // see also:
+    // https://stackoverflow.com/questions/1106377/detect-when-a-browser-receives-a-file-download
     window.addEventListener('focus', this.clearLoadingState)
   },
   destroyed () {

--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -50,7 +50,6 @@ export default {
       this.isLoading = false
     },
     setLoadingState () {
-      console.log('setLoadingState()')
       this.isLoading = true
     }
   }

--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -1,0 +1,60 @@
+<template>
+  <a
+    download
+    :href="href"
+    class="btn btn-primary"
+    :class="computedClasses"
+    @click="setLoadingState"
+  >
+    <span
+      v-if="isLoading"
+      class="spinner-border spinner-border-sm"
+      role="status"
+      aria-hidden="true"
+    ></span>
+    <span v-if="isLoading"> Loading...</span>
+    <span v-else> <slot /></span>
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'DownloadButton',
+  props: {
+    href: String,
+    customClass: String,
+    classes: Object
+  },
+  mounted () {
+    window.addEventListener('focus', this.clearLoadingState)
+  },
+  destroyed () {
+    window.addEventListener('focus', this.clearLoadingState)
+  },
+  data () {
+    return {
+      isLoading: false
+    }
+  },
+  computed: {
+    computedClasses () {
+      return {
+        ...this.classes,
+
+        // override parent disabled class if in loading state
+        // disabled: this?.classes?.disabled || this.isLoading
+        disabled: this.isLoading
+      }
+    }
+  },
+  methods: {
+    clearLoadingState () {
+      this.isLoading = false
+    },
+    setLoadingState () {
+      console.log('setLoadingState()')
+      this.isLoading = true
+    }
+  }
+}
+</script>

--- a/src/components/DownloadTemplateBtn.vue
+++ b/src/components/DownloadTemplateBtn.vue
@@ -1,5 +1,5 @@
 <template>
-  <DownloadButton :href="href" :classes="classes">
+  <DownloadButton :href="href" :classes="classes" :disabled="isDisabled">
     Download Empty Template
   </DownloadButton>
 </template>
@@ -29,7 +29,6 @@ export default {
       return {
         'btn-block': this.block,
         'btn-secondary': true
-        // disabled: this.isDisabled
       }
     }
   }

--- a/src/components/DownloadTemplateBtn.vue
+++ b/src/components/DownloadTemplateBtn.vue
@@ -1,14 +1,19 @@
 <template>
-  <a download :href="href" class="btn btn-secondary" :class="classes">
+  <DownloadButton :href="href" :classes="classes">
     Download Empty Template
-  </a>
+  </DownloadButton>
 </template>
 
 <script>
+import DownloadButton from './DownloadButton.vue'
+
 export default {
   name: 'DownloadTemplateBtn',
   props: {
     block: Boolean
+  },
+  components: {
+    DownloadButton
   },
   computed: {
     periodId: function () {
@@ -22,8 +27,9 @@ export default {
     },
     classes: function () {
       return {
-        'disabled': this.isDisabled,
-        'btn-block': this.block
+        'btn-block': this.block,
+        'btn-secondary': true
+        // disabled: this.isDisabled
       }
     }
   }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="row mt-5 mb-5" v-if="viewingOpenPeriod">
       <div class="col" v-if="isAdmin">
-        <a :href="downloadUrl()" class="btn btn-primary btn-block">Download Treasury Report</a>
+        <DownloadButton :href="downloadUrl()" class="btn btn-primary btn-block">Download Treasury Report</DownloadButton>
       </div>
 
       <div class="col" v-if="isAdmin && false">
@@ -43,7 +43,8 @@
 </template>
 
 <script>
-import DownloadTemplateBtn from '../components/DownloadTemplateBtn'
+import DownloadButton from '../components/DownloadButton.vue'
+import DownloadTemplateBtn from '../components/DownloadTemplateBtn.vue'
 
 export default {
   name: 'Home',
@@ -73,6 +74,7 @@ export default {
     }
   },
   components: {
+    DownloadButton,
     DownloadTemplateBtn
   }
 }


### PR DESCRIPTION
I rewrote this on top of the latest UI changes, and in a way that hopefully supports all download buttons!

![Screen Shot 2022-05-23 at 7 17 35 pm](https://user-images.githubusercontent.com/11449340/169935723-4ade46a9-4015-4dbe-87bc-84231790a5fc.png)
![Screen Shot 2022-05-23 at 7 17 28 pm](https://user-images.githubusercontent.com/11449340/169935726-8a61f89e-612f-4ff9-92f1-fd84ed648c16.png)
![Screen Shot 2022-05-23 at 7 18 17 pm](https://user-images.githubusercontent.com/11449340/169935711-e2800958-a06c-41fc-a80b-f53d1e02e0d9.png)
![Screen Shot 2022-05-23 at 7 17 04 pm](https://user-images.githubusercontent.com/11449340/169935700-abb816a7-af2a-4ec4-9af6-7731976e8966.png)


