### PR TITLE
Set "engines" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "arpa-reporter",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "16.x.x"
+  },
   "scripts": {
     "serve": "concurrently \"npm:dev:*\"",
     "dev:vue": "vue-cli-service serve",


### PR DESCRIPTION
Low priority!

I opted to set a node version via the "engines" property of our `package.json`.  The advantage of setting a version this way is that yarn will also be able to enforce it locally.

This ensures that the version of node we run locally won't diverge significantly from what's running in production.

I chose v16 since v16 is the latest version of node that meets the following criteria:

- in "long term support" ([LTS](https://nodejs.org/en/about/releases/))
- supports our version of Vue CLI
- supports our version of Express
- was released at least 6 months ago (node 18 was released 2022-04-19)

I didn't identify any breakages on v18, so we could try it if we wanted.  v16 just seemed a smidge safer.

Fixes #64