### PR TITLE
Use custom bootstrap file input

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "aws-sdk": "^2.963.0",
     "body-parser": "^1.19.0",
     "bootstrap": "^4.6.1",
+    "bs-custom-file-input": "1.3.4",
     "connect-history-api-fallback": "^1.6.0",
     "cookie-parser": "^1.4.5",
     "core-js": "^3.21.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,8 +7,13 @@
 <script>
 import '../scss/index.scss'
 import 'bootstrap/dist/js/bootstrap.min.js'
+import bsCustomFileInput from 'bs-custom-file-input'
 
-import Navigation from '@/components/Navigation.vue'
+import Navigation from './components/Navigation.vue'
+
+window.addEventListener('load', function () {
+  bsCustomFileInput.init()
+})
 
 export default {
   name: 'App',

--- a/src/views/NewUpload.vue
+++ b/src/views/NewUpload.vue
@@ -15,14 +15,19 @@
         @submit.prevent="onSubmit"
       >
         <div class="form-group">
-          <input
-            class="form-control"
-            type="file"
-            id="spreadsheet"
-            name="spreadsheet"
-            @change="changeFiles"
-            ref="files"
-          />
+          <div class="custom-file">
+            <input
+              class="custom-file-input"
+              type="file"
+              id="spreadsheet"
+              name="spreadsheet"
+              @change="changeFiles"
+              ref="files"
+            />
+            <label class="custom-file-label" for="spreadsheet">
+              {{fileInputLabel}}
+            </label>
+          </div>
         </div>
         <div class="form-group">
           <button
@@ -56,6 +61,9 @@ export default {
     },
     uploadDisabled: function () {
       return this.files === null || this.uploading
+    },
+    fileInputLabel: function () {
+      return this.files?.[0]?.name ?? 'Choose Files'
     }
   },
   methods: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3242,6 +3242,11 @@ browserslist@^4.16.3, browserslist@^4.16.6:
     node-releases "^2.0.2"
     picocolors "^1.0.0"
 
+bs-custom-file-input@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/bs-custom-file-input/-/bs-custom-file-input-1.3.4.tgz#c275cb8d4f1c02ba026324292509fa9a747dbda8"
+  integrity sha512-NBsQzTnef3OW1MvdKBbMHAYHssCd613MSeJV7z2McXznWtVMnJCy7Ckyc+PwxV6Pk16cu6YBcYWh/ZE0XWNKCA==
+
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"


### PR DESCRIPTION
Install the bootstrap custom file input plugin and apply it to our file input.

Fancier, but we load a few extra kilobytes, and there's a chance there are weird bugs.

![Screen Shot 2022-05-25 at 7 13 44 pm](https://user-images.githubusercontent.com/11449340/170401784-1aa4c8ac-db31-4563-b639-5a13a63e0327.png)

Alternative: #278