### PR TITLE
Use bootstrap's recommended form-control-file class

### DIFF
--- a/src/views/NewUpload.vue
+++ b/src/views/NewUpload.vue
@@ -16,7 +16,7 @@
       >
         <div class="form-group">
           <input
-            class="form-control"
+            class="form-control-file"
             type="file"
             id="spreadsheet"
             name="spreadsheet"


### PR DESCRIPTION
The current layout just looks janky to me, so I tried to clean it up.  Apparently bootstrap recommends the `form-control-file` class to avoid this.

https://getbootstrap.com/docs/4.6/components/forms/#form-controls

BEFORE

![Screen Shot 2022-05-25 at 7 20 56 pm](https://user-images.githubusercontent.com/11449340/170402228-93a6a94b-a1c1-4815-bb18-ebc60e7229fc.png)

AFTER

![Screen Shot 2022-05-25 at 7 15 32 pm](https://user-images.githubusercontent.com/11449340/170402251-f26bec9a-b1e0-4dc9-bed1-a246220fd4b9.png)

Alternative: #277