### PR TITLE
Upload: correct display of in-series uploads

### DIFF
--- a/src/server/services/revalidate-uploads.js
+++ b/src/server/services/revalidate-uploads.js
@@ -1,8 +1,8 @@
 const { validateUpload } = require('./validate-upload')
-const { listUploads } = require('../db/uploads')
+const { uploadsInPeriod } = require('../db/uploads')
 
 async function revalidateUploads (period, user, trns) {
-  const uploads = await listUploads({ periodId: period.id }, trns)
+  const uploads = await uploadsInPeriod(period.id, trns)
 
   const updates = []
   for (const upload of uploads) {


### PR DESCRIPTION
we had several logic bugs here. first, our series display was listing
uploads for other EC codes, since we were only filtering by agency.
next, we likewise were also filtering only by agency when determining
the current valid period.

we refactor our db functions to use the same base query for consistency.
we also better-name our db query functions after what they're used for,
removing the overly-general `listUploads` (the filtering by various
fields there has moved to the front end in vue-good-table)

fixes #276 