### PR TITLE
Support EC7 templates in treasury export

### DIFF
--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -479,7 +479,9 @@ async function generateProjectBaseline (records) {
         case '2.37':
         case '3.3':
         case '3.4':
-        case '3.5': {
+        case '3.5':
+        case '7.1':
+        case '7.2': {
           return [
             null, // first col is blank
             record.type, // FIXME: transform from sheet tab to export format


### PR DESCRIPTION
It might be slightly easier to land #302 first, then this, to avoid merge conflicts.