### PR TITLE
Igor/standard form

### DIFF
--- a/src/components/StandardForm.vue
+++ b/src/components/StandardForm.vue
@@ -1,0 +1,111 @@
+<template>
+  <div>
+    <div class="form-group row" v-for="col in cols" :key="col.field">
+      <label :for="col.field" class="col-sm-2 col-form-label">{{ col.label }}</label>
+
+      <div class="col-sm-10" >
+        <select
+          v-if="col.selectItems && col.selectItems.length > 0"
+          class="form-control"
+          :id="col.field"
+          v-model="record[col.field]"
+          :readonly="col.readonly"
+          :class="classesForField(col.field)"
+          :aria-describedby="`feedback-${col.field}`"
+          >
+          <option v-for="opt in col.selectItems" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+
+        <input
+          v-else
+          type="text"
+          class="form-control"
+          :id="col.field"
+          v-model="record[col.field]"
+          :readonly="col.readonly"
+          :class="classesForField(col.field)"
+          :aria-describedby="`feedback-${col.field}`"
+          />
+
+        <div :id="`feedback-${col.field}`" class="invalid-feedback">
+          <span v-for="error in errors[col.field]" :key="error">
+            {{ error }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <div class="form-group row">
+      <div class="col-sm-2"></div>
+      <div class="col-sm-10">
+        <button class="btn btn-primary" v-on:click="validateAndSave()" :disabled="disabled">Save</button>
+        <button class="btn btn-secondary ml-2" v-on:click="$emit('reset')" :disabled="disabled">Reset</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'StandardForm',
+  props: {
+    initialRecord: Object,
+    cols: Array,
+    /* example: {
+      label: 'Person name',
+      field: 'person_name',
+      readonly: false,
+      selectItems: [
+        label: 'None', value: null,
+        label: 'Bob', value: 'Robert'
+      ],
+      validations: [
+        {
+        }
+      ]
+    } */
+    disabled: Boolean
+  },
+  data: function () {
+    return {
+      wasValidated: false,
+      record: Object.fromEntries(this.cols.map(col => [col.field, this.initialRecord[col.field]])),
+      errors: Object.fromEntries(this.cols.map(col => [col.field, []]))
+    }
+  },
+  methods: {
+    classesForField: function (field) {
+      const col = this.cols.find(col => col.field === field)
+      if (col.readonly) return {}
+      if (!this.wasValidated) return {}
+
+      return {
+        'is-valid': this.errors[field].length === 0,
+        'is-invalid': this.errors[field].length > 0
+      }
+    },
+    validateAndSave: function () {
+      this.cols.forEach(col => {
+        const field = col.field
+        const val = this.record[field]
+
+        // clear errors; we will re-set them if they still exist
+        this.errors[field] = []
+
+        // check required fields
+        if (col.required && (val === undefined || val === null || val === '')) {
+          this.errors[field].push(`${col.label} is a required field`)
+        }
+      })
+
+      this.wasValidated = true
+      const hasErrors = Object.values(this.errors).some(errList => errList.length > 0)
+      if (!hasErrors) {
+        this.$emit('save', this.record)
+      }
+    }
+  }
+}
+</script>

--- a/src/components/StandardForm.vue
+++ b/src/components/StandardForm.vue
@@ -57,13 +57,10 @@ export default {
       label: 'Person name',
       field: 'person_name',
       readonly: false,
+      required: true,
       selectItems: [
         label: 'None', value: null,
         label: 'Bob', value: 'Robert'
-      ],
-      validations: [
-        {
-        }
       ]
     } */
     disabled: Boolean

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -108,12 +108,6 @@ const routes = [
     meta: { requiresLogin: true }
   },
   {
-    path: '/new_user',
-    name: 'NewUser',
-    component: User,
-    meta: { requiresLogin: true }
-  },
-  {
     path: '/users/:id',
     name: 'User',
     component: User,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -60,12 +60,6 @@ const routes = [
     meta: { requiresLogin: true }
   },
   {
-    path: '/new_agency',
-    name: 'NewAgency',
-    component: Agency,
-    meta: { requiresLogin: true }
-  },
-  {
     path: '/agencies/:id',
     name: 'Agency',
     component: Agency,

--- a/src/server/db/agencies.js
+++ b/src/server/db/agencies.js
@@ -1,21 +1,24 @@
 
 const knex = require('./connection')
 
-function agencies (trns = knex) {
+function baseQuery (trns) {
   return trns('agencies')
     .select('*')
+}
+
+function agencies (trns = knex) {
+  return baseQuery(trns)
     .orderBy('name')
 }
 
 function agencyById (id, trns = knex) {
-  return trns('agencies')
-    .select('*')
+  return baseQuery(trns)
     .where('id', id)
     .then(r => r[0])
 }
 
 function agencyByCode (code, trns = knex) {
-  return trns('agencies')
+  return baseQuery(trns)
     .select('*')
     .where({ code })
 }
@@ -24,13 +27,8 @@ function createAgency (agency, trns = knex) {
   return trns
     .insert(agency)
     .into('agencies')
-    .returning(['id'])
-    .then(response => {
-      return {
-        ...agency,
-        id: response[0].id
-      }
-    })
+    .returning('*')
+    .then(r => r[0])
 }
 
 function updateAgency (agency, trns = knex) {
@@ -40,6 +38,8 @@ function updateAgency (agency, trns = knex) {
       code: agency.code,
       name: agency.name
     })
+    .returning('*')
+    .then(r => r[0])
 }
 
 module.exports = {

--- a/src/server/db/users.js
+++ b/src/server/db/users.js
@@ -4,7 +4,8 @@ const knex = require('./connection')
 
 function users (trns = knex) {
   return trns('users')
-    .select('*')
+    .leftJoin('agencies', 'users.agency_id', 'agencies.id')
+    .select('users.*', 'agencies.name AS agency_name', 'agencies.code AS agency_code')
     .orderBy('email')
 }
 

--- a/src/server/db/users.js
+++ b/src/server/db/users.js
@@ -10,17 +10,10 @@ function users (trns = knex) {
 }
 
 function createUser (user, trns = knex) {
-  return trns
+  return trns('users')
     .insert(user)
-    .into('users')
-    .returning(['id', 'created_at'])
-    .then(response => {
-      return {
-        ...user,
-        id: response[0].id,
-        created_at: response[0].created_at
-      }
-    })
+    .returning('*')
+    .then(rows => rows[0])
 }
 
 function updateUser (user, trns = knex) {
@@ -32,6 +25,8 @@ function updateUser (user, trns = knex) {
       role: user.role,
       agency_id: user.agency_id
     })
+    .returning('*')
+    .then(rows => rows[0])
 }
 
 function user (id, trns = knex) {

--- a/src/server/routes/agencies.js
+++ b/src/server/routes/agencies.js
@@ -4,7 +4,6 @@ const { requireAdminUser, requireUser } = require('../access-helpers')
 const router = express.Router()
 const {
   agencies,
-  agencyById: getAgency,
   createAgency,
   updateAgency
 } = require('../db/agencies')
@@ -13,63 +12,41 @@ router.get('/', requireUser, function (req, res) {
   agencies().then(agencies => res.json({ agencies }))
 })
 
-async function validateAgency (req, res, next) {
-  const { name, code } = req.body
-  if (!name) {
-    res.status(400).send('Agency requires a name')
-    return
+async function validateAgency (agency) {
+  if (!agency.name) {
+    throw new Error('Agency requires a name')
   }
-  if (!code) {
-    res.status(400).send('Agency requires a code')
-    return
+  if (!agency.code) {
+    throw new Error('Agency requires a code')
   }
-  next()
 }
 
-router.post('/', requireAdminUser, validateAgency, function (req, res, next) {
-  console.log('POST /agencies', req.body)
-  const { code, name } = req.body
-  const agency = {
-    code,
-    name
-  }
-  createAgency(agency)
-    .then(result => res.json({ agency: result }))
-    .catch(e => {
-      if (e.message.match(/violates unique constraint/)) {
-        res.status(400).send('Agency with that code already exists')
-      } else {
-        next(e)
-      }
-    })
-})
+router.post('/', requireAdminUser, async function (req, res, next) {
+  const agencyInfo = req.body.agency
+  console.dir(agencyInfo)
 
-router.put('/:id', requireAdminUser, validateAgency, async function (
-  req,
-  res,
-  next
-) {
-  console.log('PUT /agencies/:id', req.body)
-  let agency = await getAgency(req.params.id)
-  if (!agency) {
-    res.status(400).send('Agency not found')
+  try {
+    await validateAgency(agencyInfo)
+  } catch (e) {
+    res.status(400).json({ error: e.message })
     return
   }
-  const { code, name } = req.body
-  agency = {
-    ...agency,
-    code,
-    name
+
+  try {
+    if (agencyInfo.id) {
+      const agency = await updateAgency(agencyInfo)
+      res.json({ agency })
+    } else {
+      const agency = await createAgency(agencyInfo)
+      res.json({ agency })
+    }
+  } catch (e) {
+    if (e.message.match(/violates unique constraint/)) {
+      res.status(400).json({ error: 'Agency with that code already exists' })
+    } else {
+      res.status(500).json({ error: e.message })
+    }
   }
-  updateAgency(agency)
-    .then(result => res.json({ agency: result }))
-    .catch(e => {
-      if (e.message.match(/violates unique constraint/)) {
-        res.status(400).send('Agency with that code already exists')
-      } else {
-        next(e)
-      }
-    })
 })
 
 module.exports = router

--- a/src/server/routes/configuration.js
+++ b/src/server/routes/configuration.js
@@ -3,14 +3,12 @@
 const express = require('express')
 const router = express.Router()
 const { requireUser } = require('../access-helpers')
-const { user: getUser, users: getUsers, roles: getRoles } = require('../db/users')
+const { roles: getRoles } = require('../db/users')
 
 router.get('/', requireUser, async function (req, res) {
-  const user = await getUser(req.signedCookies.userId)
-  const users = user.role === 'admin' ? await getUsers() : [user]
   const roles = await getRoles()
 
-  res.json({ configuration: { users, roles } })
+  res.json({ configuration: { roles } })
 })
 
 module.exports = router

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -45,8 +45,6 @@ router.post('/', requireAdminUser, async function (req, res, next) {
   const user = req.body.user
   user.email = user.email.toLowerCase().trim()
 
-  console.dir(user)
-
   try {
     await validateUser(user)
   } catch (e) {

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -3,7 +3,7 @@
 const express = require('express')
 const router = express.Router()
 const { requireUser, requireAdminUser } = require('../access-helpers')
-const { createUser, users: listUsers, updateUser, roles: listRoles } = require('../db/users')
+const { createUser, users: listUsers, updateUser } = require('../db/users')
 const { agencyById } = require('../db/agencies')
 const { sendWelcomeEmail } = require('../lib/email')
 const _ = require('lodash-checkit')
@@ -37,8 +37,7 @@ router.get('/', requireUser, async function (req, res, next) {
   const curUser = allUsers.find(u => u.id === Number(req.signedCookies.userId))
 
   const users = (curUser.role === 'admin') ? allUsers : [curUser]
-  const roles = await listRoles()
-  res.json({ users, roles })
+  res.json({ users })
 })
 
 router.post('/', requireAdminUser, async function (req, res, next) {
@@ -60,7 +59,7 @@ router.post('/', requireAdminUser, async function (req, res, next) {
       const updatedUser = await createUser(user)
       res.json({ user: updatedUser })
 
-      sendWelcomeEmail(updatedUser.email, req.headers.origin)
+      void sendWelcomeEmail(updatedUser.email, req.headers.origin)
     }
   } catch (e) {
     console.dir(e)

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -3,109 +3,76 @@
 const express = require('express')
 const router = express.Router()
 const { requireUser, requireAdminUser } = require('../access-helpers')
-const { createUser, user: getUser, users: listUsers, updateUser } = require('../db/users')
+const { createUser, users: listUsers, updateUser, roles: listRoles } = require('../db/users')
 const { agencyById } = require('../db/agencies')
 const { sendWelcomeEmail } = require('../lib/email')
 const _ = require('lodash-checkit')
 
-async function validateUser (req, res, next) {
-  const { email, role, agency_id } = req.body
+async function validateUser (user) {
+  const { email, role, agency_id } = user
   if (!email) {
-    res.status(400).send('User email is required')
-    return
+    throw new Error('User email is required')
   }
   if (!_.isEmail(email)) {
-    res.status(400).send('Invalid email address')
-    return
+    throw new Error('Invalid email address')
   }
   if (!role) {
-    res.status(400).send('Role required')
-    return
+    throw new Error('Role required')
   }
+
   if (agency_id) {
     const agency = await agencyById(agency_id)
     if (!agency) {
-      res.status(400).send('Invalid agency')
-      return
+      throw new Error('Invalid agency')
     }
   } else if (role !== 'admin') {
-    res.status(400).send('Reporter role requires agency')
-    return
+    throw new Error('Reporter role requires agency')
   }
-  next()
+
+  return null
 }
 
 router.get('/', requireUser, async function (req, res, next) {
   const allUsers = await listUsers()
   const curUser = allUsers.find(u => u.id === Number(req.signedCookies.userId))
 
-  let users
-  if (curUser.role === 'admin') {
-    if (curUser.agency_id) {
-      users = allUsers.filter(u => u.agency_id === curUser.agency_id)
-    } else {
-      users = allUsers
-    }
-  } else {
-    users = [curUser]
-  }
-
-  res.json({ users })
+  const users = (curUser.role === 'admin') ? allUsers : [curUser]
+  const roles = await listRoles()
+  res.json({ users, roles })
 })
 
-router.post('/', requireAdminUser, validateUser, async function (
-  req,
-  res,
-  next
-) {
-  console.log('POST /users', req.body)
-  const { email, name, role, agency_id } = req.body
-  const user = {
-    email: email.toLowerCase().trim(),
-    role,
-    name,
-    agency_id
-  }
-  createUser(user)
-    .then(result => res.json({ user: result }))
-    .then(() => sendWelcomeEmail(user.email, req.headers.origin))
-    .catch(e => {
-      if (e.message.match(/violates unique constraint/)) {
-        res.status(400).send('User with that email already exists')
-      } else {
-        next(e)
-      }
-    })
-})
+router.post('/', requireAdminUser, async function (req, res, next) {
+  const user = req.body.user
+  user.email = user.email.toLowerCase().trim()
 
-router.put('/:id', requireAdminUser, validateUser, async function (
-  req,
-  res,
-  next
-) {
-  console.log('PUT /users/:id', req.body)
-  let user = await getUser(req.params.id)
-  if (!user) {
-    res.status(400).send('User not found')
+  console.dir(user)
+
+  try {
+    await validateUser(user)
+  } catch (e) {
+    res.status(400).json({ error: e.message })
     return
   }
-  const { email, name, role, agency_id } = req.body
-  user = {
-    ...user,
-    email: email.toLowerCase().trim(),
-    name,
-    role,
-    agency_id
+
+  try {
+    if (user.id) {
+      const updatedUser = await updateUser(user)
+      res.json({ user: updatedUser })
+    } else {
+      const updatedUser = await createUser(user)
+      res.json({ user: updatedUser })
+
+      sendWelcomeEmail(updatedUser.email, req.headers.origin)
+    }
+  } catch (e) {
+    console.dir(e)
+
+    if (e.message.match(/violates unique constraint/)) {
+      res.status(400).json({ error: 'User with that email already exists' })
+    } else {
+      next(e)
+    }
   }
-  updateUser(user)
-    .then(result => res.json({ user: result }))
-    .catch(e => {
-      if (e.message.match(/violates unique constraint/)) {
-        res.status(400).send('User with that email already exists')
-      } else {
-        next(e)
-      }
-    })
 })
 
 module.exports = router

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -132,15 +132,6 @@ export default new Vuex.Store({
         state.viewPeiodID = applicationSettings.current_reporting_period_id
       }
     },
-    addAgency (state, agency) {
-      state.agencies = _.sortBy([...state.agencies, agency], 'name')
-    },
-    updateAgency (state, agency) {
-      state.agencies = _.chain(state.agencies)
-        .map(a => (agency.id === a.id ? agency : a))
-        .sortBy('name')
-        .value()
-    },
     addMessage (state, message) {
       state.messages = [...state.messages, message]
     },
@@ -224,16 +215,6 @@ export default new Vuex.Store({
           }
           return response
         })
-    },
-    createAgency ({ commit }, agency) {
-      return post('/api/agencies', agency).then(response => {
-        commit('addAgency', response.agency)
-      })
-    },
-    updateAgency ({ commit }, agency) {
-      return put(`/api/agencies/${agency.id}`, agency).then(() => {
-        commit('updateAgency', agency)
-      })
     },
     setViewPeriodID ({ commit }, period_id) {
       commit('setViewPeriodID', period_id)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -192,14 +192,6 @@ export default new Vuex.Store({
           commit('setViewPeriodID', data.application_settings.current_reporting_period_id)
         })
     },
-    createUser ({ commit }, user) {
-      return post('/api/users', user).then(response => {
-      })
-    },
-    updateUser ({ commit }, user) {
-      return put(`/api/users/${user.id}`, user).then(() => {
-      })
-    },
     createTemplate ({ commit }, { reportingPeriodId, formData }) {
       return postForm(`/api/reporting_periods/${reportingPeriodId}/template`, formData)
         .then(r => {
@@ -310,6 +302,9 @@ export default new Vuex.Store({
     viewPeriodIsCurrent: state => {
       return Number(state.viewPeriodID) ===
         Number(state.applicationSettings.current_reporting_period_id)
+    },
+    roles: state => {
+      return state.configuration.roles
     }
   }
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -132,18 +132,6 @@ export default new Vuex.Store({
         state.viewPeiodID = applicationSettings.current_reporting_period_id
       }
     },
-    addUser (state, user) {
-      state.configuration.users = _.sortBy(
-        [...state.configuration.users, user],
-        'email'
-      )
-    },
-    updateUser (state, user) {
-      state.configuration.users = _.chain(state.configuration.users)
-        .map(u => (user.id === u.id ? user : u))
-        .sortBy('email')
-        .value()
-    },
     addAgency (state, agency) {
       state.agencies = _.sortBy([...state.agencies, agency], 'name')
     },
@@ -215,12 +203,10 @@ export default new Vuex.Store({
     },
     createUser ({ commit }, user) {
       return post('/api/users', user).then(response => {
-        commit('addUser', response.user)
       })
     },
     updateUser ({ commit }, user) {
       return put(`/api/users/${user.id}`, user).then(() => {
-        commit('updateUser', user)
       })
     },
     createTemplate ({ commit }, { reportingPeriodId, formData }) {

--- a/src/views/Agencies.vue
+++ b/src/views/Agencies.vue
@@ -3,7 +3,7 @@
     <h2>Agencies</h2>
 
     <div class="mb-4">
-      <router-link to="/new_agency" class="btn btn-primary">
+      <router-link to="/agencies/new" class="btn btn-primary">
         Create New Agency
       </router-link>
     </div>

--- a/src/views/Agency.vue
+++ b/src/views/Agency.vue
@@ -16,7 +16,7 @@
         </div>
       </div>
 
-      <StandardForm :initialRecord="agency" :cols="cols" @save="onSave" @reset="onReset" />
+      <StandardForm :initialRecord="agency" :cols="cols" @save="onSave" @reset="onReset" :key="formKey" />
     </div>
   </div>
 </template>
@@ -28,6 +28,11 @@ import { post } from '../store'
 
 export default {
   name: 'Agency',
+  data: function () {
+    return {
+      formKey: Date.now()
+    }
+  },
   computed: {
     agencyId: function () {
       return this.$route.params.id
@@ -75,7 +80,7 @@ export default {
       }
     },
     onReset () {
-      this.$store.dispatch('updateAgencies')
+      this.formKey = Date.now()
     }
   },
   watch: {
@@ -84,7 +89,7 @@ export default {
     }
   },
   mounted: async function () {
-    this.onReset()
+    this.$store.dispatch('updateAgencies')
   },
   components: {
     StandardForm

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -84,11 +84,20 @@ export default {
         const result = await post('/api/users', { user })
         if (result.error) throw new Error(result.error)
 
-        this.user = result.user
+        const text = this.isNew
+          ? `User ${result.user.id} successfully created`
+          : `User ${result.user.email} successfully updated`
+
         this.$store.commit('addAlert', {
-          text: `User ${user.email} successfully updated`,
+          text,
           level: 'ok'
         })
+
+        if (this.isNew) {
+          return this.$router.push(`/users/${result.user.id}`)
+        } else {
+          this.user = result.user
+        }
       } catch (err) {
         this.user = user
         this.$store.commit('addAlert', {
@@ -99,9 +108,6 @@ export default {
     },
     onReset () {
       this.loadUser()
-    },
-    onDone () {
-      return this.$router.push('/users')
     }
   },
   watch: {

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -16,7 +16,7 @@
         </div>
       </div>
 
-      <StandardForm :initialRecord="user" :cols="cols" @save="onSave" @reset="onReset" />
+      <StandardForm :initialRecord="user" :cols="cols" @save="onSave" @reset="onReset" :key="formKey" />
     </div>
   </div>
 </template>
@@ -30,7 +30,7 @@ export default {
   data: function () {
     return {
       user: null,
-      roles: []
+      formKey: Date.now()
     }
   },
   computed: {
@@ -45,9 +45,12 @@ export default {
         { label: 'ID', field: 'id', readonly: true },
         { label: 'Email', field: 'email', required: true },
         { label: 'Name', field: 'name', required: true },
-        { label: 'Role', field: 'role', selectItems: this.roleItems },
+        { label: 'Role', field: 'role', selectItems: this.roleItems, required: true },
         { label: 'Agency', field: 'agency_id', selectItems: this.agencyItems }
       ]
+    },
+    roles: function () {
+      return this.$store.getters.roles || []
     },
     roleItems: function () {
       return this.roles.map(r => ({ label: r.name, value: r.name }))
@@ -60,6 +63,11 @@ export default {
   },
   methods: {
     loadUser: async function () {
+      if (this.isNew) {
+        this.user = {}
+        return
+      }
+
       this.user = null
 
       const result = await getJson('/api/users')
@@ -69,12 +77,7 @@ export default {
           level: 'err'
         })
       } else {
-        this.roles = result.roles
-        if (this.isNew) {
-          this.user = {}
-        } else {
-          this.user = result.users.find(u => u.id === Number(this.userId))
-        }
+        this.user = result.users.find(u => u.id === Number(this.userId))
       }
     },
     onSave: async function (user) {
@@ -107,7 +110,7 @@ export default {
       }
     },
     onReset () {
-      this.loadUser()
+      this.formKey = Date.now()
     }
   },
   watch: {

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -2,9 +2,9 @@
   <div>
     <h2>Users</h2>
     <div class="mb-4">
-      <router-link to="/new_user" class="btn btn-primary"
-        >Create New User</router-link
-      >
+      <router-link to="/users/new" class="btn btn-primary">
+        Create New User
+      </router-link>
     </div>
 
     <vue-good-table
@@ -86,9 +86,6 @@ export default {
     }
   },
   methods: {
-    agencyName (id) {
-      return this.$store.getters.agencyName(id)
-    },
     loadUsers: async function (evt) {
       const result = await getJson('/api/users')
       if (result.error) {

--- a/tests/unit/views/Home.spec.js
+++ b/tests/unit/views/Home.spec.js
@@ -10,7 +10,7 @@ describe('Home.vue', () => {
   it('renders', () => {
     const store = new Vuex.Store({
       state: {
-        viewPeriodID: 0,
+        viewPeriodID: 0
       },
       getters: {
         user: () => ({ email: 'admin@example.com', role: 'admin' }),

--- a/tests/unit/views/Home.spec.js
+++ b/tests/unit/views/Home.spec.js
@@ -11,9 +11,6 @@ describe('Home.vue', () => {
     const store = new Vuex.Store({
       state: {
         viewPeriodID: 0,
-        configuration: {
-          templates: [{ name: 'Agency' }]
-        }
       },
       getters: {
         user: () => ({ email: 'admin@example.com', role: 'admin' }),

--- a/tests/unit/views/User.spec.js
+++ b/tests/unit/views/User.spec.js
@@ -6,30 +6,38 @@ import Vuex from 'vuex'
 const localVue = createLocalVue()
 localVue.use(Vuex)
 
+const mocks = {
+  $route: {
+    path: '/users/new',
+    params: {
+      id: 'new'
+    }
+  }
+}
+
 describe('User.vue', () => {
   let store
+
   beforeEach(() => {
     store = new Vuex.Store({
       state: {
-        configuration: {
-          roles: [{ name: 'admin' }, { name: 'reporter' }]
-        }
+        agencies: [{ name: 'A1' }, { name: 'A2' }]
       },
       getters: {
-        agencies: () => [{ name: 'A1' }, { name: 'A2' }]
+        roles: () => [{ name: 'admin' }]
+      },
+      mutations: {
+        addAlert: () => null
       }
     })
   })
-  it('renders new user form', () => {
-    const wrapper = mount(User, { store, localVue })
-    const r = wrapper.find('button.btn-primary')
-    expect(r.text()).to.include('Create User')
-  })
-  it('requires a non blank email', async () => {
-    const wrapper = mount(User, { store, localVue })
-    await wrapper.find('button').trigger('click')
-    setTimeout(() => {
-      expect(wrapper.find('.alert').text()).to.equal('Email is required')
-    }, 0) // not sure why this is necessary
+  it('renders new user form', async () => {
+    const wrapper = mount(User, { store, localVue, mocks })
+    const loading = wrapper.find('div[role="status"]')
+    expect(loading.text()).to.include('Loading')
+
+    await wrapper.setData({ user: {} })
+    const form = wrapper.findComponent({ name: 'StandardForm' })
+    expect(form.exists()).to.equal(true)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3597,7 +3597,7 @@ chardet@^0.7.0:
 check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
-  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 checkit@^0.7.0:
   version "0.7.0"
@@ -6092,7 +6092,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
 get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
@@ -7989,9 +7989,9 @@ loose-envify@^1.4.0:
     js-tokens "^3.0.0 || ^4.0.0"
 
 loupe@^2.3.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.3.tgz#5a92027d54cfb6de4c327d3c3b705561d394d3c6"
-  integrity sha512-krIV4Cf1BIGIx2t1e6tucThhrBemUnIUjMtD2vN4mrMxnxpBvrcosBSpooqunBqP/hOEEV1w/Cr1YskGtqw5Jg==
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
+  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
   dependencies:
     get-func-name "^2.0.0"
 


### PR DESCRIPTION
This is a cleanup PR which probably doesn't need to exist. We tackle two issues:

1. `RecordForm` is kind of a weird abstraction, with lots of configuration that's not being used
2. Our create/update flow for users and agencies was kinda odd, with updates attempting to happen in several places (on the backend, but also in the store) and functionality spread between several components and the store

Here, we switch to using a new abstraction -- `StandardForm` -- for users, agencies, and subrecipients. Additionally, combine create and update code paths for these, both on the front-end (via front-end routes) and the back-end (by using http `POST` for both). 

Unlike `RecordForm`, which requires passing update methods as props, `StandardForm` emits events for reset and save, which allows the parent component to handle update functionality.

We refactor some code out of the store, further reducing it in size. This PR definitely conflicts with usdigitalresponse/arpa-reporter#308 -- sorry about that!

We cannot yet remove `RecordForm` because it's still in use in the `ReportingPeriod` component. Refactoring `ReportingPeriod` warrants it's own PR, because the front-end state for this is a total mess, with lots of getters, difficult to follow initialization flow, and duplicate buts of state like `allReportingPeriods` and `reportingPeriods`. This would certainly require touching a bunch of code, including in the store and in dependent components, and so would further affect usdigitalresponse/arpa-reporter#308 

Recommend implementing usdigitalresponse/usdr-gost#396 on top of this PR, maybe by adding props to `StandardForm` like `enableDelete` (maybe also `enableCancel`?) and then handling the appropriate events.