### PR TITLE
Refactor reporting period management

### DIFF
--- a/migrations/20220616180456_overhaul_reporting_periods.js
+++ b/migrations/20220616180456_overhaul_reporting_periods.js
@@ -1,0 +1,48 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('reporting_periods', function (table) {
+    table.dropColumn('review_period_end_date')
+    table.dropColumn('review_period_start_date')
+    table.dropColumn('close_date')
+    table.dropColumn('open_date')
+
+    table.dropColumn('validation_rule_tags')
+    table.dropColumn('reporting_template')
+
+    table.dropColumn('period_of_performance_end_date')
+
+    table.integer('certified_by').unsigned().alter()
+    table.foreign('certified_by').references('users.id')
+
+    table.string('template_filename')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema
+    .table('reporting_periods', function (table) {
+      table.dropForeign('certified_by')
+    })
+    .alterTable('reporting_periods', function (table) {
+      table.dropColumn('template_filename')
+
+      table.text('certified_by').alter()
+
+      table.date('period_of_performance_end_date')
+
+      table.text('reporting_template')
+      table.specificType('validation_rule_tags', 'TEXT[]')
+
+      table.date('open_date')
+      table.date('close_date')
+      table.date('review_period_start_date')
+      table.date('review_period_end_date')
+    })
+}

--- a/seeds/04_reporting_periods.js
+++ b/seeds/04_reporting_periods.js
@@ -31,17 +31,11 @@ exports.seed = async function (knex) {
   const finalStart = moment('2026-10-01')
   while (!start.isAfter(finalStart)) {
     const end = start.clone().add(2, 'months').endOf('month')
-    const open = end.clone().add(1, 'days')
-
-    // according to treasury, final reporting period closes end of march, not end of january
-    const close = start.isSame(finalStart) ? moment('2027-03-31') : open.clone().endOf('month')
 
     periods.push({
       name: `Quarterly ${periods.length + 1}`,
       start_date: mstr(start),
-      end_date: mstr(end),
-      open_date: mstr(open),
-      close_date: mstr(close)
+      end_date: mstr(end)
     })
 
     start.add(3, 'months')

--- a/src/server/access-helpers.js
+++ b/src/server/access-helpers.js
@@ -13,7 +13,6 @@ function requireAdminUser (req, res, next) {
     res.sendStatus(403)
   } else {
     userAndRole(req.signedCookies.userId).then(user => {
-      console.log('user:', user)
       if (user.role !== 'admin') {
         res.sendStatus(403)
       } else {

--- a/src/server/db/reporting-periods.js
+++ b/src/server/db/reporting-periods.js
@@ -13,16 +13,9 @@
    name                           | text                     |
    start_date                     | date                     |
    end_date                       | date                     |
-   period_of_performance_end_date | date                     |
    certified_at                   | timestamp with time zone |
    certified_by                   | text                     |
    reporting_template             | text                     |
-   validation_rule_tags           | text[]                   |
-   open_date                      | date                     |
-   close_date                     | date                     |
-   review_period_start_date       | date                     |
-   review_period_end_date         | date                     |
-   final_report_file              | text                     |
 */
 const knex = require('./connection')
 const { log } = require('../lib/log')
@@ -186,8 +179,6 @@ function updateReportingPeriod (reportingPeriod, trns = knex) {
       name: cleanString(reportingPeriod.name),
       start_date: reportingPeriod.start_date,
       end_date: reportingPeriod.end_date,
-      period_of_performance_end_date: reportingPeriod.period_of_performance_end_date,
-      crf_end_date: reportingPeriod.crf_end_date,
       reporting_template: reportingPeriod.reporting_template
     })
 }

--- a/src/server/db/settings.js
+++ b/src/server/db/settings.js
@@ -41,14 +41,12 @@ function applicationSettings () {
 
 /* currentReportingPeriodSettings() returns:
   {
+    id: 1,
     title: 'Ohio',
     current_reporting_period_id: 1,
-    duns_number: '809031776',
-    id: 1,
     name: 'September 2020',
     start_date: 2020-03-01T06:00:00.000Z,
     end_date: 2020-09-30T05:00:00.000Z,
-    period_of_performance_end_date: 2020-12-30T06:00:00.000Z
   }
 
   reporting period record in db:
@@ -56,11 +54,8 @@ function applicationSettings () {
     name
     start_date
     end_date
-    period_of_performance_end_date
     certified_at
     certified_by
-    reporting_template
-    validation_rule_tags
  */
 async function currentReportingPeriodSettings (trns = knex) {
   let rv

--- a/src/server/db/settings.js
+++ b/src/server/db/settings.js
@@ -1,84 +1,29 @@
 const knex = require('./connection')
-let currentReportingPeriodID = null
 
-// setCurrentReportingPeriod()
 function setCurrentReportingPeriod (id, trns = knex) {
-  currentReportingPeriodID = id
   return trns('application_settings')
     .update('current_reporting_period_id', id)
 }
 
-// update application_settings set current_reporting_period_id=1;
 async function getCurrentReportingPeriodID (trns = knex) {
-  if (currentReportingPeriodID !== null) {
-    return currentReportingPeriodID
-  }
-  let crpID
-  try {
-    crpID = await trns('application_settings')
-      .select('*')
-      .then(r => {
-        currentReportingPeriodID = r[0].current_reporting_period_id
-        return currentReportingPeriodID
-      })
-  } catch (err) {
-    console.dir(err)
-    return err
-  }
-  return crpID
+  return trns('application_settings')
+    .select('*')
+    .then(r => r[0].current_reporting_period_id)
 }
 
-/*  applicationSettings() returns
-  {
-    title: 'Ohio',
-    current_reporting_period_id: 1,
-    duns_number: '809031776'
-  }
-  */
-function applicationSettings () {
-  return currentReportingPeriodSettings()
-}
-
-/* currentReportingPeriodSettings() returns:
-  {
-    id: 1,
-    title: 'Ohio',
-    current_reporting_period_id: 1,
-    name: 'September 2020',
-    start_date: 2020-03-01T06:00:00.000Z,
-    end_date: 2020-09-30T05:00:00.000Z,
-  }
-
-  reporting period record in db:
-    id
-    name
-    start_date
-    end_date
-    certified_at
-    certified_by
- */
-async function currentReportingPeriodSettings (trns = knex) {
-  let rv
-  try {
-    rv = await trns('application_settings')
-      .join(
-        'reporting_periods',
-        'application_settings.current_reporting_period_id',
-        'reporting_periods.id'
-      )
-      .select('*')
-      .then(rv => rv[0])
-  } catch (err) {
-    console.dir(err)
-  }
-  return rv
+async function applicationSettings (trns = knex) {
+  return await trns('application_settings')
+    .join(
+      'reporting_periods',
+      'application_settings.current_reporting_period_id',
+      'reporting_periods.id'
+    )
+    .select('*')
+    .then(rows => rows[0])
 }
 
 module.exports = {
   applicationSettings,
-  currentReportingPeriodSettings,
   getCurrentReportingPeriodID,
   setCurrentReportingPeriod
 }
-
-/*                                 *  *  *                                    */

--- a/src/server/environment.js
+++ b/src/server/environment.js
@@ -8,6 +8,7 @@ const POSTGRES_URL = process.env.POSTGRES_URL
 
 const DATA_DIR = resolve(process.env.DATA_DIR)
 const UPLOAD_DIR = join(DATA_DIR, 'uploads')
+const PERIOD_TEMPLATES_DIR = join(UPLOAD_DIR, 'period_templates')
 
 const SRC_DIR = resolve(join(__dirname, '..'))
 const SERVER_DATA_DIR = join(SRC_DIR, 'server', 'data')
@@ -35,6 +36,7 @@ const SES_REGION = process.env.SES_REGION
 module.exports = {
   DATA_DIR,
   UPLOAD_DIR,
+  PERIOD_TEMPLATES_DIR,
   SRC_DIR,
   SERVER_DATA_DIR,
   EMPTY_TEMPLATE_NAME,

--- a/src/server/routes/reporting-periods.js
+++ b/src/server/routes/reporting-periods.js
@@ -31,9 +31,7 @@ router.get('/summaries/', requireUser, async function (req, res) {
 })
 
 router.post('/close/', requireAdminUser, async (req, res) => {
-  console.log('POST /reporting_periods/close/')
-
-  const period = await reportingPeriods.getReportingPeriod()
+  const period = await reportingPeriods.get()
   const user = await getUser(req.signedCookies.userId)
 
   const trns = await knex.transaction()
@@ -42,7 +40,7 @@ router.post('/close/', requireAdminUser, async (req, res) => {
     trns.commit()
   } catch (err) {
     if (!trns.isCompleted()) trns.rollback()
-    return res.status(500).send(err.message)
+    return res.status(500).json({ error: err.message })
   }
 
   res.json({

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -167,16 +167,6 @@ export default new Vuex.Store({
     setViewPeriodID ({ commit }, period_id) {
       commit('setViewPeriodID', period_id)
     },
-    closeReportingPeriod ({ commit, dispatch }, period_id) {
-      return fetch('/api/reporting_periods/close', { credentials: 'include', method: 'POST' })
-        .then(r => {
-          if (r.ok) {
-            dispatch('updateReportingPeriods')
-            dispatch('updateApplicationSettings')
-          }
-          return r
-        })
-    },
 
     async updateUploads ({ commit, state }) {
       const params = new URLSearchParams({ period_id: state.viewPeriodID })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -164,20 +164,6 @@ export default new Vuex.Store({
     logout ({ commit }) {
       fetch('/api/sessions/logout').then(() => commit('setUser', null))
     },
-    createTemplate ({ commit, dispatch }, { reportingPeriodId, formData }) {
-      return postForm(`/api/reporting_periods/${reportingPeriodId}/template`, formData)
-        .then(r => {
-          if (!r.ok) { throw new Error(`createTemplate: ${r.statusText} (${r.status})`) }
-          return r.json()
-        })
-        .then(response => {
-          if (response.success) {
-            dispatch('updateReportingPeriods')
-            dispatch('updateApplicationSettings')
-          }
-          return response
-        })
-    },
     setViewPeriodID ({ commit }, period_id) {
       commit('setViewPeriodID', period_id)
     },

--- a/src/views/ReportingPeriod.vue
+++ b/src/views/ReportingPeriod.vue
@@ -38,7 +38,8 @@ export default {
         { field: 'id', label: 'ID', readonly: true },
         { field: 'name', label: 'Period Name', required: true },
         { field: 'start_date', label: 'Reporting Period Start Date', required: true, inputType: 'date' },
-        { field: 'end_date', label: 'Reporting Period End Date', required: true, inputType: 'date' }
+        { field: 'end_date', label: 'Reporting Period End Date', required: true, inputType: 'date' },
+        { field: 'template_filename', label: 'Upload Template Name', readonly: true }
       ]
     }
   },

--- a/src/views/ReportingPeriod.vue
+++ b/src/views/ReportingPeriod.vue
@@ -38,9 +38,7 @@ export default {
         { field: 'id', label: 'ID', readonly: true },
         { field: 'name', label: 'Period Name', required: true },
         { field: 'start_date', label: 'Reporting Period Start Date', required: true, inputType: 'date' },
-        { field: 'end_date', label: 'Reporting Period End Date', required: true, inputType: 'date' },
-        { field: 'open_date', label: 'Opens', readonly: true, inputType: 'date' },
-        { field: 'close_date', label: 'Closes', readonly: true, inputType: 'date' }
+        { field: 'end_date', label: 'Reporting Period End Date', required: true, inputType: 'date' }
       ]
     }
   },

--- a/src/views/ReportingPeriods.vue
+++ b/src/views/ReportingPeriods.vue
@@ -49,28 +49,24 @@
       </tbody>
     </table>
 
-    <div class="mt-3 alert alert-danger" v-if="errorMessage">
-      {{ errorMessage }}
-    </div>
-
-    <div class="modal modal-fade" tabindex="-1" role="dialog" id="certify-reporting-period">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Certify Reporting Period</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <p>Certify the <b>{{ currentPeriod.name }}</b> period?</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-primary" @click.prevent="handleCertify">Certify</button>
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                </div>
-            </div>
+    <div class="modal fade" tabindex="-1" role="dialog" id="certify-reporting-period">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Certify Reporting Period</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close" ref="closeModal">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>Certify the <b>{{ currentPeriod.name }}</b> period?</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" @click="handleCertify">Certify</button>
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+          </div>
         </div>
+      </div>
     </div>
   </div>
 </template>
@@ -78,12 +74,12 @@
 <script>
 const moment = require('moment')
 const _ = require('lodash')
+
 export default {
   name: 'ReportingPeriods',
   data: function () {
     return {
-      certifying: false,
-      errorMessage: null
+      certifying: false
     }
   },
   computed: {
@@ -110,22 +106,30 @@ export default {
     reportPeriodUrl: function (p) {
       return `/reporting_periods/${p.id}`
     },
-    handleCertify: function () {
-      const el = window.$('#certify-reporting-period')
-      if (el) {
-        el.modal('hide')
-        this.certifying = true
-        this.errorMessage = null
-        this.$store.dispatch('closeReportingPeriod', this.currentPeriod.id)
-          .then((r) => {
-            if (!r.ok) {
-              r.text().then(errorMessage => {
-                this.errorMessage = errorMessage
-              })
-            }
-            this.certifying = false
-          })
+    handleCertify: async function () {
+      this.certifying = true
+      this.$refs.closeModal.click()
+
+      try {
+        const resp = await fetch('/api/reporting_periods/close', { method: 'POST' })
+        const result = resp.headers.get('Content-Type').includes('json')
+          ? await resp.json()
+          : { error: await resp.text() }
+
+        if (resp.ok) {
+          this.$store.dispatch('updateReportingPeriods')
+          this.$store.dispatch('updateApplicationSettings')
+        } else {
+          throw new Error(result.error)
+        }
+      } catch (e) {
+        this.$store.commit('addAlert', {
+          text: `Error certifying reporting period: ${e.message}`,
+          level: 'err'
+        })
       }
+
+      this.certifying = false
     },
     formatDate (d) {
       return moment(d).utc().format('MM/DD/YYYY')

--- a/src/views/ReportingPeriods.vue
+++ b/src/views/ReportingPeriods.vue
@@ -25,7 +25,7 @@
           <td>{{ p.name }}</td>
           <td>{{ formatDate(p.start_date) }}</td>
           <td>{{ formatDate(p.end_date) }}</td>
-          <td>{{ p.reporting_template }}</td>
+          <td>{{ p.template_filename }}</td>
           <td>
             <a v-if="!p.certified_at" :href="`/new_template/${p.id}`">Upload Template</a>
           </td>
@@ -39,7 +39,7 @@
               >{{ certifyLabel }}</button>
             </span>
             <span v-else-if="p.certified_at">
-              {{ formatDate(p.certified_at) }}
+              {{ formatDate(p.certified_at) }} by {{ p.certified_by_email }}
             </span>
           </td>
           <td>

--- a/tests/server/db/settings.spec.js
+++ b/tests/server/db/settings.spec.js
@@ -3,9 +3,9 @@ const settings = requireSrc(__filename)
 const assert = require('assert')
 
 describe('application settings db', function () {
-  describe('currentReportingPeriodSettings', function () {
+  describe('applicationSettings', function () {
     it('Returns the current reporting period & title', async () => {
-      const result = await settings.currentReportingPeriodSettings()
+      const result = await settings.applicationSettings()
 
       assert.equal(result.current_reporting_period_id, 1)
       assert.equal(result.title, 'Rhode Island')
@@ -16,7 +16,7 @@ describe('application settings db', function () {
     let savedReportingPeriod
 
     beforeEach('save current period', async function () {
-      const curr = await settings.currentReportingPeriodSettings()
+      const curr = await settings.applicationSettings()
       savedReportingPeriod = curr.current_reporting_period_id
     })
 
@@ -27,7 +27,7 @@ describe('application settings db', function () {
     it('Changes the current reporting period', async () => {
       await settings.setCurrentReportingPeriod(2)
 
-      const result = await settings.currentReportingPeriodSettings()
+      const result = await settings.applicationSettings()
       assert.equal(result.current_reporting_period_id, 2)
     })
   })

--- a/tests/server/seeds/07_reporting_periods.js
+++ b/tests/server/seeds/07_reporting_periods.js
@@ -10,9 +10,7 @@ exports.seed = async function (knex) {
     {
       name: 'Quarterly 1',
       start_date: '2021-03-03',
-      end_date: '2021-12-31',
-      open_date: '2022-01-01',
-      close_date: '2022-01-31'
+      end_date: '2021-12-31'
     }
   ]
 
@@ -24,28 +22,15 @@ exports.seed = async function (knex) {
   const finalStart = moment('2026-10-01')
   while (!start.isAfter(finalStart)) {
     const end = start.clone().add(2, 'months').endOf('month')
-    const open = end.clone().add(1, 'days')
-
-    // according to treasury, final reporting period closes end of march, not end of january
-    const close = start.isSame(finalStart) ? moment('2027-03-31') : open.clone().endOf('month')
 
     periods.push({
       name: `Quarterly ${periods.length + 1}`,
       start_date: mstr(start),
-      end_date: mstr(end),
-      open_date: mstr(open),
-      close_date: mstr(close)
+      end_date: mstr(end)
     })
 
     start.add(3, 'months')
   }
-
-  // not sure what these fields are used for; these might be unnecessary
-  periods.forEach(period => {
-    period.period_of_performance_end_date = period.end_date
-    period.review_period_start_date = mstr(moment(period.open_date).add(2, 'weeks'))
-    period.review_period_end_date = period.close_date
-  })
 
   await knex('reporting_periods').insert(periods)
 }


### PR DESCRIPTION
We do a few things here:

* Remove the oodles of unused columns on the `reporting_periods` table
* Make the `certified_by` a FK reference to users
* Change the way custom period templates are stored (which fixes #309 )
* Moves remaining single-purpose API interactions into relevant components (for uploading a template and certifying a reporting period)
* fix faulty logic around certification, which should fix the comment we heard this afternoon re "I always have to ask Larry to certify the period for me"
