### PR TITLE
Refactor: db/reporting-periods exports verbose names

### DIFF
--- a/src/server/db/reporting-periods.js
+++ b/src/server/db/reporting-periods.js
@@ -26,13 +26,12 @@ const {
 } = require('./settings')
 
 module.exports = {
-  get: getReportingPeriod,
-  close: closeReportingPeriod,
-
-  getID: getPeriodID,
-  isCurrent,
-  isClosed,
-  getAll,
+  getReportingPeriod,
+  closeReportingPeriod,
+  getReportingPeriodID,
+  isReportingPeriodCurrent,
+  isReportingPeriodClosed,
+  getAllReportingPeriods,
   createReportingPeriod,
   updateReportingPeriod
 }
@@ -46,7 +45,7 @@ function baseQuery (trns) {
     .leftJoin('users', 'reporting_periods.certified_by', 'users.id')
 }
 
-async function getAll (trns = knex) {
+async function getAllReportingPeriods (trns = knex) {
   return baseQuery(trns).orderBy('end_date', 'desc')
 }
 
@@ -66,7 +65,7 @@ async function getReportingPeriod (period_id, trns = knex) {
   }
 }
 
-async function isClosed (periodId) {
+async function isReportingPeriodClosed (periodId) {
   return getReportingPeriod(periodId)
     .then(period => {
       return Boolean(period.certified_at)
@@ -76,14 +75,14 @@ async function isClosed (periodId) {
 /*  getPeriodID() returns the argument unchanged unless it is falsy, in which
   case it returns the current reporting period ID.
   */
-async function getPeriodID (periodID) {
+async function getReportingPeriodID (periodID) {
   return Number(periodID) || getCurrentReportingPeriodID()
 }
 
 /*  isCurrent() returns the current reporting period ID if the argument is
     falsy, or if it matches the current reporting period ID
   */
-async function isCurrent (periodID) {
+async function isReportingPeriodCurrent (periodID) {
   const currentID = await getCurrentReportingPeriodID()
 
   if (!periodID || (Number(periodID) === Number(currentID))) {

--- a/src/server/lib/audit-report.js
+++ b/src/server/lib/audit-report.js
@@ -1,7 +1,7 @@
 const moment = require('moment')
 const XLSX = require('xlsx')
 
-const { get, getAll } = require('../db/reporting-periods')
+const { getReportingPeriod, getAllReportingPeriods } = require('../db/reporting-periods')
 const { getCurrentReportingPeriodID } = require('../db/settings')
 const { recordsForUpload } = require('../services/records')
 const { log } = require('../lib/log')
@@ -39,8 +39,8 @@ async function generate () {
 
 async function createObligationSheet (periodId) {
   // select active reporting periods and sort by date
-  const currentReportingPeriod = await get(periodId)
-  const allReportingPeriods = await getAll()
+  const currentReportingPeriod = await getReportingPeriod(periodId)
+  const allReportingPeriods = await getAllReportingPeriods()
   const reportingPeriods = allReportingPeriods.filter(
     (period) =>
       new Date(period.end_date) <= new Date(currentReportingPeriod.end_date)

--- a/src/server/routes/exports.js
+++ b/src/server/routes/exports.js
@@ -6,13 +6,13 @@ const _ = require('lodash')
 
 const { requireUser } = require('../access-helpers')
 const arpa = require('../services/generate-arpa-report')
-const reportingPeriods = require('../db/reporting-periods')
+const { getReportingPeriodID, isReportingPeriodCurrent } = require('../db/reporting-periods')
 
 router.get('/', requireUser, async function (req, res) {
-  const periodId = await reportingPeriods.getID(req.query.period_id)
+  const periodId = await getReportingPeriodID(req.query.period_id)
 
   let generator
-  if (await reportingPeriods.isCurrent(periodId)) {
+  if (await isReportingPeriodCurrent(periodId)) {
     console.log(`periodId ${periodId} is current`)
     generator = arpa.generateReport
   } else {

--- a/src/server/routes/uploads.js
+++ b/src/server/routes/uploads.js
@@ -11,7 +11,7 @@ const multerUpload = multer({ storage: multer.memoryStorage() })
 
 const knex = require('../db/connection')
 const { user: getUser } = require('../db/users')
-const reportingPeriods = require('../db/reporting-periods')
+const { getReportingPeriodID } = require('../db/reporting-periods')
 const { usedForTreasuryExport, getUpload, uploadsInSeries, uploadsInPeriod } = require('../db/uploads')
 
 const { recordsForUpload } = require('../services/records')
@@ -20,7 +20,7 @@ const { validateUpload } = require('../services/validate-upload')
 const ValidationError = require('../lib/validation-error')
 
 router.get('/', requireUser, async function (req, res) {
-  const periodId = await reportingPeriods.getID(req.query.period_id)
+  const periodId = await getReportingPeriodID(req.query.period_id)
   const uploads = await uploadsInPeriod(periodId)
   return res.json({ uploads })
 })

--- a/src/server/services/get-template.js
+++ b/src/server/services/get-template.js
@@ -4,7 +4,7 @@ const { mkdir, readFile, writeFile } = require('fs/promises')
 const xlsx = require('xlsx')
 const { SERVER_DATA_DIR, EMPTY_TEMPLATE_NAME, PERIOD_TEMPLATES_DIR } = require('../environment')
 
-const reportingPeriods = require('../db/reporting-periods')
+const { getReportingPeriod, updateReportingPeriod } = require('../db/reporting-periods')
 
 // cache treasury templates in memory after first load
 const treasuryTemplates = new Map()
@@ -23,7 +23,7 @@ function periodTemplatePath (reportingPeriod) {
 }
 
 async function savePeriodTemplate (periodId, fileName, buffer) {
-  const reportingPeriod = await reportingPeriods.get(periodId)
+  const reportingPeriod = await getReportingPeriod(periodId)
 
   await mkdir(PERIOD_TEMPLATES_DIR, { recursive: true })
   await writeFile(
@@ -33,7 +33,7 @@ async function savePeriodTemplate (periodId, fileName, buffer) {
   )
 
   reportingPeriod.template_filename = fileName
-  await reportingPeriods.updateReportingPeriod(reportingPeriod)
+  await updateReportingPeriod(reportingPeriod)
 }
 
 async function getTemplate (templateName) {
@@ -62,7 +62,7 @@ async function loadTemplate (templateName) {
 }
 
 async function templateForPeriod (periodId) {
-  const reportingPeriod = await reportingPeriods.get(periodId)
+  const reportingPeriod = await getReportingPeriod(periodId)
 
   if (reportingPeriod.template_filename) {
     const filename = reportingPeriod.template_filename

--- a/src/server/services/persist-upload.js
+++ b/src/server/services/persist-upload.js
@@ -5,7 +5,7 @@ const { mkdir, writeFile, readFile } = require('fs/promises')
 
 const xlsx = require('xlsx')
 
-const reportingPeriods = require('../db/reporting-periods')
+const { getReportingPeriod } = require('../db/reporting-periods')
 const { createUpload } = require('../db/uploads')
 const { UPLOAD_DIR } = require('../environment')
 const ValidationError = require('../lib/validation-error')
@@ -24,7 +24,7 @@ async function persistUpload ({ filename, user, buffer }) {
   }
 
   // get the current reporting period
-  const reportingPeriod = await reportingPeriods.get()
+  const reportingPeriod = await getReportingPeriod()
 
   // create an upload
   const uploadRow = {

--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -1,7 +1,7 @@
 
 const moment = require('moment')
 
-const { get: getReportingPeriod } = require('../db/reporting-periods')
+const { getReportingPeriod } = require('../db/reporting-periods')
 const { setAgencyId, setEcCode, markValidated, markNotValidated } = require('../db/uploads')
 const { agencyByCode } = require('../db/agencies')
 const { createRecipient, findRecipient, updateRecipient } = require('../db/arpa-subrecipients')

--- a/tests/server/db/reporting-periods.spec.js
+++ b/tests/server/db/reporting-periods.spec.js
@@ -22,13 +22,13 @@
 
 */
 
-const reportingPeriods = requireSrc(__filename)
+const { getAllReportingPeriods, getReportingPeriod } = requireSrc(__filename)
 const assert = require('assert')
 
 describe('db/reporting-periods.js', function () {
   describe('getAll', function () {
     it('Returns a list of reporting periods', async function () {
-      const result = await reportingPeriods.getAll()
+      const result = await getAllReportingPeriods()
       assert.equal(result.length, 21)
     })
   })
@@ -36,21 +36,21 @@ describe('db/reporting-periods.js', function () {
   describe('get', function () {
     describe('when a specific id is passed', function () {
       it('Returns that reporting period', async function () {
-        const result = await reportingPeriods.get(2)
+        const result = await getReportingPeriod(2)
         assert.equal(result.id, 2)
       })
     })
 
     describe('when an invalid id is passed', function () {
       it('returns null', async function () {
-        assert.equal((await reportingPeriods.get('')), null)
-        assert.equal((await reportingPeriods.get(null)), null)
-        assert.equal((await reportingPeriods.get(12356)), null)
+        assert.equal((await getReportingPeriod('')), null)
+        assert.equal((await getReportingPeriod(null)), null)
+        assert.equal((await getReportingPeriod(12356)), null)
       })
     })
 
     it('returns the current reporting period', async function () {
-      const result = await reportingPeriods.get()
+      const result = await getReportingPeriod()
       assert.equal(result.id, 1)
       assert.equal(result.title, undefined)
     })


### PR DESCRIPTION
This is a follow-up for the following comment:

https://github.com/usdigitalresponse/arpa-reporter/pull/317#discussion_r897073256