### PR TITLE
Change the `uploads` table primary key to a UUID

### DIFF
--- a/migrations/20220627001634_remove_validation_messages.js
+++ b/migrations/20220627001634_remove_validation_messages.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .dropTable('validation_messages')
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema
+    .createTable('validation_messages', function (table) {
+      table.increments('id').primary()
+      table.integer('upload_id').unsigned()
+      table.foreign('upload_id').references('uploads.id')
+      table.text('message')
+      table.text('tab')
+      table.integer('row')
+      table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
+    })
+}

--- a/migrations/20220627001742_key_uploads_with_uuid.js
+++ b/migrations/20220627001742_key_uploads_with_uuid.js
@@ -1,0 +1,45 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .alterTable('arpa_subrecipients', function (table) {
+      table.dropForeign('upload_id')
+      table.dropColumn('upload_id')
+    })
+    .alterTable('uploads', function (table) {
+      table.dropPrimary()
+      table.dropColumn('id')
+    })
+    .alterTable('uploads', function (table) {
+      table.uuid('id').defaultTo(knex.raw('gen_random_uuid()')).primary()
+    })
+    .alterTable('arpa_subrecipients', function (table) {
+      table.uuid('upload_id')
+      table.foreign('upload_id').references('uploads.id').onDelete('cascade')
+    })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema
+    .alterTable('arpa_subrecipients', function (table) {
+      table.dropForeign('upload_id')
+      table.dropColumn('upload_id')
+    })
+    .alterTable('uploads', function (table) {
+      table.dropPrimary()
+      table.dropColumn('id')
+    })
+    .alterTable('uploads', function (table) {
+      table.increments('id').primary()
+    })
+    .alterTable('arpa_subrecipients', function (table) {
+      table.integer('upload_id').unsigned()
+      table.foreign('upload_id').references('uploads.id').onDelete('cascade')
+    })
+}

--- a/src/helpers/short-uuid.js
+++ b/src/helpers/short-uuid.js
@@ -1,0 +1,8 @@
+
+/**
+ * Shorten a UUID to make it a little less intimidating when presented in a UI.
+ * @param {string} uuid The UUID to shorten.
+ */
+export function shortUuid (uuid) {
+  return uuid.split('-')[0]
+}

--- a/src/server/routes/uploads.js
+++ b/src/server/routes/uploads.js
@@ -45,7 +45,7 @@ router.post('/', requireUser, multerUpload.single('spreadsheet'), async (req, re
 })
 
 router.get('/:id', requireUser, async (req, res) => {
-  const id = Number(req.params.id)
+  const id = req.params.id
 
   const upload = await getUpload(id)
   if (!upload || upload.tenant_id !== req.session.user.tenant_id) {

--- a/src/server/services/persist-upload.js
+++ b/src/server/services/persist-upload.js
@@ -11,7 +11,7 @@ const { UPLOAD_DIR } = require('../environment')
 const ValidationError = require('../lib/validation-error')
 
 const uploadFSName = (upload) => {
-  const filename = `upload-id-${upload.id}${path.extname(upload.filename)}`
+  const filename = `${upload.id}${path.extname(upload.filename)}`
   return path.join(UPLOAD_DIR, filename)
 }
 

--- a/src/views/Upload.vue
+++ b/src/views/Upload.vue
@@ -38,7 +38,7 @@
     </div>
 
     <div class="row">
-      <h4 class="col">Upload # {{ uploadId }} details:</h4>
+      <h4 class="col">Upload {{ shortUploadId }} details:</h4>
     </div>
 
     <div v-if="upload" class="row">
@@ -161,6 +161,7 @@ import { titleize } from '../helpers/form-helpers'
 import AlertBox from '../components/AlertBox'
 import DownloadIcon from '../components/DownloadIcon'
 import { getJson, post } from '../store'
+import { shortUuid } from '../helpers/short-uuid'
 
 export default {
   name: 'Upload',
@@ -181,6 +182,9 @@ export default {
   computed: {
     uploadId: function () {
       return this.$route.params.id
+    },
+    shortUploadId: function () {
+      return shortUuid(this.uploadId)
     },
     isRecentlyUploaded: function () {
       return this.uploadId === this.$store.state.recentUploadId

--- a/src/views/Upload.vue
+++ b/src/views/Upload.vue
@@ -180,7 +180,7 @@ export default {
   },
   computed: {
     uploadId: function () {
-      return Number(this.$route.params.id)
+      return this.$route.params.id
     },
     isRecentlyUploaded: function () {
       return this.uploadId === this.$store.state.recentUploadId

--- a/src/views/Uploads.vue
+++ b/src/views/Uploads.vue
@@ -41,7 +41,7 @@
       <template slot="table-row" slot-scope="props">
         <span v-if="props.column.field === 'id'">
           <router-link :to="`/uploads/${props.row.id}`">
-            {{ props.row.id }}
+            {{ shortUuid(props.row.id) }}
           </router-link>
         </span>
 
@@ -68,6 +68,7 @@ import DownloadIcon from '../components/DownloadIcon'
 import DownloadTemplateBtn from '../components/DownloadTemplateBtn'
 
 import { getJson } from '../store'
+import { shortUuid } from '../helpers/short-uuid'
 
 export default {
   name: 'Uploads',
@@ -191,6 +192,7 @@ export default {
       this.$refs.uploadsTable.reset()
       this.$refs.uploadsTable.changeSort([])
     },
+    shortUuid,
     loadExportedUploads: async function (evt) {
       this.exportedUploads = []
       if (!this.onlyExported) return

--- a/src/views/Uploads.vue
+++ b/src/views/Uploads.vue
@@ -140,9 +140,8 @@ export default {
 
       return [
         {
-          label: '#',
-          field: 'id',
-          type: 'number'
+          label: 'ID',
+          field: 'id'
         },
         {
           label: 'Agency',


### PR DESCRIPTION
First, this change is totally optional!  I don't think it's that bad if we never expunge auto-incrementing IDs from the ARPA reporter.

However, if we are interested in moving toward UUID (or other string-like) keys, I think uploads is probably the most valuable table to migrate now.  This is because once we have real reporting cycles underway, upload IDs will exist in quite a few places.

Upload IDs as foreign keys can be migrated, but upload IDs will also end up in upload files persisted on disk as well as in upload links in audit reports.  Resolving _all_ discrepancies after-the-fact may never be completely possible.

---

If we do tackle this change now, we should have one less set of ID conflicts to deal with whenever we merge RI, CT and OH instances.  👍 

@igor47 if you do manage to take a look at this, I'd especially like your thoughts on what to do with the UI.  Full UUIDs are kind of clunky to render to text.

<img width="1359" alt="image" src="https://user-images.githubusercontent.com/11449340/175845333-2e938c96-c4cd-457e-a4ed-ba092cabbd12.png">

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/11449340/175845377-347b7574-f825-4039-8ca5-af2611a66491.png">

**NOTE**: I think it's also interesting to consider something other than a full UUID for our keys.  I don't think we're ever expecting millions of uploads in the system.  We could use a git-style md5 hash, for instance?