### PR TITLE
Document deployment process with RENDER.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 ARPA Reporter is a web app designed to ease the ARPA grants reporting workflow for government agencies and grants offices. It aggregates reports from individual agencies or groups, and provides quick, up-front validation of all errors before submitting to federal portals, which can be a painful and iterative process otherwise.
 
-## Developer documentation
-This readme.md page explains how to set up your development environment. Documentation for sysadmins is at https://github.com/usdigitalresponse/arpa-reporter/wiki/Home.
+## Render Administration
+
+See [RENDER.md](RENDER.md) for documentation relating to deploying this project on https://render.com/.
 
 ## Project setup
 

--- a/RENDER.md
+++ b/RENDER.md
@@ -1,0 +1,28 @@
+# Render Deployment
+
+To set up a new pair of render instances for a state, follow the below steps!
+
+### Create a new GitHub branch:
+
+1. Create new branch: render-[state]
+2. Open `render.yaml` for editing
+3. Replace `arpa-reporter-web` with `arpa-reporter-[state]`
+4. Replace `arpa-reporter-db` with `arpa-reporter-[state]-db` (in the TWO places it appears)
+5. Save changes
+
+### Create new Blueprint instance:
+
+1. Log into Render.com and load the USDR dashboard
+1. Click on the *Blueprints* tab
+1. Select *New Blueprint Instance*
+1. Set *Service Group Name* to: [state] USDR ARPA Reporter
+1. Select your new branch to load render.yaml from
+1. Set the appropriate environment variables (for now, copy from an existing instance)
+
+### Once instances are set up:
+
+1. Open the new web service
+1. Click on the "shell" tab
+1. Run `yarn db:init`
+
+You're done! Open up the new site and log in.


### PR DESCRIPTION
We should remove this file when merging ARPA and GOST repositories.