### PR TITLE
Igor/validation fixes ozzie

### DIFF
--- a/src/server/services/records.js
+++ b/src/server/services/records.js
@@ -24,6 +24,9 @@ const DATA_SHEET_TYPES = {
   'Aggregate Awards < 50000': 'awards'
 }
 
+const TYPE_TO_SHEET_NAME = Object.fromEntries(
+  Object.entries(DATA_SHEET_TYPES).map(([sheetName, type]) => [type, sheetName]))
+
 function readVersionRecord (workbook) {
   const range = {
     s: { r: 0, c: 1 },
@@ -112,5 +115,6 @@ module.exports = {
   recordsForReportingPeriod,
   recordsForUpload,
   DATA_SHEET_TYPES,
+  TYPE_TO_SHEET_NAME,
   readVersionRecord
 }

--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -229,8 +229,18 @@ async function validateRecord ({ upload, record, typeRules: rules, trns }) {
       continue
     }
 
+    // if the field is unset/missing/blank, is that okay?
+    if ([undefined, null, ''].includes(record[key])) {
+      // make sure required keys are present
+      if (rule.required === true) {
+        errors.push(new ValidationError(
+          `Value is required for ${key}`,
+          { col: rule.columnName, severity: 'err' }
+        ))
+      }
+
     // if there's something in the field, make sure it meets requirements
-    if (record[key]) {
+    } else {
       // make sure pick value is one of pick list values
       if (rule.listVals.length > 0) {
         // for pick lists, the value must be one of possible values
@@ -265,16 +275,6 @@ async function validateRecord ({ upload, record, typeRules: rules, trns }) {
         }
 
         // TODO: should we validate max length on currency? or numeric fields?
-      }
-
-    // if the field is unset, is that okay?
-    } else {
-      // make sure required keys are present
-      if (rule.required === true) {
-        errors.push(new ValidationError(
-          `Value is required for ${key}`,
-          { col: rule.columnName, severity: 'err' }
-        ))
       }
     }
   }

--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -243,21 +243,25 @@ async function validateRecord ({ upload, record, typeRules: rules, trns }) {
     } else {
       // make sure pick value is one of pick list values
       if (rule.listVals.length > 0) {
+        // enforce validation in lower case
+        const lcItems = rule.listVals.map(val => val.toLowerCase())
+        const lcVal = String(record[key]).toLowerCase()
+
         // for pick lists, the value must be one of possible values
-        if (rule.dataType === 'Pick List' && rule.listVals.indexOf(record[key]) < 0) {
+        if (rule.dataType === 'Pick List' && lcItems.indexOf(lcVal) < 0) {
           errors.push(new ValidationError(
-            `Value for ${key} must be one of ${rule.listVals.length} options in the input template`,
+            `Value for ${key} must be one of ${lcItems.length} options in the input template`,
             { col: rule.columnName, severity: 'err' }
           ))
         }
 
         // for multi select, all the values must be in the list of possible values
         if (rule.dataType === 'Multi-Select') {
-          const entries = record[key].split(';').map(val => val.trim())
+          const entries = lcVal.split(';').map(val => val.trim())
           for (const entry of entries) {
-            if (rule.listVals.indexOf(entry) < 0) {
+            if (lcItems.indexOf(entry) < 0) {
               errors.push(new ValidationError(
-                `Entry '${entry}' of ${key} is not one of ${rule.listVals.length} valid options`,
+                `Entry '${entry}' of ${key} is not one of ${lcItems.length} valid options`,
                 { col: rule.columnName, severity: 'err' }
               ))
             }

--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -230,6 +230,7 @@ async function validateRecord ({ upload, record, typeRules: rules, trns }) {
     }
 
     // if the field is unset/missing/blank, is that okay?
+    // we don't treat numeric `0` as unset
     if ([undefined, null, ''].includes(record[key])) {
       // make sure required keys are present
       if (rule.required === true) {

--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -256,11 +256,15 @@ async function validateRecord ({ upload, record, typeRules: rules, trns }) {
       }
 
       // make sure max length is not too long
-      if (rule.maxLength && String(record[key]).length > rule.maxLength) {
-        errors.push(new ValidationError(
-          `Value for ${key} cannot be longer than ${rule.maxLength} (currently, ${String(record[key]).length})`,
-          { col: rule.columnName, severity: 'err' }
-        ))
+      if (rule.maxLength) {
+        if (rule.dataType === 'String' && String(record[key]).length > rule.maxLength) {
+          errors.push(new ValidationError(
+            `Value for ${key} cannot be longer than ${rule.maxLength} (currently, ${String(record[key]).length})`,
+            { col: rule.columnName, severity: 'err' }
+          ))
+        }
+
+        // TODO: should we validate max length on currency? or numeric fields?
       }
 
     // if the field is unset, is that okay?


### PR DESCRIPTION
Includes 4 fixes from Ozzie's email this morning:
* enforce maxlength only on `String`-type fields
* check for missing values using an explicit list
* ignore case when validating pick list/multi-select options
* set the `tab` field of validation errors back to the sheet name