### PR TITLE
Output line endings as required by Treasury portal

### DIFF
--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -955,8 +955,7 @@ async function generateReport (tenantId, periodId) {
     // can result in an opqque error that looke like the following:
     // "List index out of bounds: 1"
     const escapedContent = [...template, ...csvData].map(row =>
-      // treasury expects all values as strings
-      row.map(value => value?.toString().replace(/\r\n/g, '\n'))
+      row.map(value => typeof value === 'string' ? value.replace(/\r\n/g, '\n') : value)
     )
     const sheet = XLSX.utils.aoa_to_sheet(escapedContent, { dateNF: 'MM/DD/YYYY' })
     const csvString = XLSX.utils.sheet_to_csv(sheet, { RS: '\r\n' })

--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -951,8 +951,8 @@ async function generateReport (tenantId, periodId) {
     const template = await getTemplate(name)
 
     // 2022-07-08 Treasury expects LF line endings _within_ cells and CRLF line
-    // endings _between+ rows.  Failure to adhere to either of these rquirements
-    // can result in an opqque error that looke like the following:
+    // endings _between_ rows.  Failure to adhere to either of these requirements
+    // can result in an opaque error that looks like the following:
     // "List index out of bounds: 1"
     const escapedContent = [...template, ...csvData].map(row =>
       row.map(value => typeof value === 'string' ? value.replace(/\r\n/g, '\n') : value)


### PR DESCRIPTION
To test this, I downloaded Joe's latest test template (10003d) from Google Drive.

- Upload this test timplate into local tool
- Download treasury export
- Log into treasury portal (details in 1password)
- Open "P&E - Mindy H. UAT Testing" profile
- Select Projects tab
- Create new project
- Select EC 1 & 1.12
- Click bulk upload link
- Upload the generated projectBaselineBulkUploadTemplate.csv file
- It should validate correctly!