### PR TITLE
Re-enable "forceQuotes" for treasury export

### DIFF
--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -965,7 +965,7 @@ async function generateReport (tenantId, periodId) {
       row.map(value => typeof value === 'string' ? value.replace(/\r\n/g, '\n') : value)
     )
     const sheet = XLSX.utils.aoa_to_sheet(escapedContent, { dateNF: 'MM/DD/YYYY' })
-    const csvString = XLSX.utils.sheet_to_csv(sheet, { RS: '\r\n' })
+    const csvString = XLSX.utils.sheet_to_csv(sheet, { forceQuotes: true, RS: '\r\n' })
     const buffer = Buffer.from(BOM + csvString, 'utf8')
 
     zip.addFile(name + '.csv', buffer)


### PR DESCRIPTION
Without this setting, some of the line breaks in the project bulk upload templates become ambiguous.

Without `forceQuotes`:

<img width="1406" alt="image" src="https://user-images.githubusercontent.com/11449340/178392877-4e08a371-a8b4-47e3-b587-a4d857aea5f0.png">

With `forceQuotes`:

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/11449340/178392694-8acfab7b-3a43-42a4-928f-2c781992b074.png">
