### PR TITLE
Format subcategories in treasury export

### DIFF
--- a/src/server/lib/format.js
+++ b/src/server/lib/format.js
@@ -6,6 +6,7 @@
  * reliably succeed if uploads have all passed validation.
  */
 const round = require('lodash/round')
+const { ecCodes } = require('./arpa-ec-codes')
 
 const EXPENDITURE_CATEGORIES = {
   ec1: '1-Public Health',
@@ -54,6 +55,18 @@ function multiselect (value) {
     .join(';')
 }
 
+/**
+ * Transform a subcategory code to its canonical name.
+ *
+ * @param {string} value
+ * The expecditure subcategory code as supplied in the input sheet
+ */
+function subcategory (value) {
+  if (value == null) return value
+  if (!ecCodes[value]) return undefined
+  return `${value}-${ecCodes[value]}`
+}
+
 function zip (value) {
   if (value == null) return value
   return value.toString().padStart(5, '0')
@@ -68,6 +81,7 @@ module.exports = {
   capitalizeFirstLetter,
   currency,
   ec,
+  subcategory,
   multiselect,
   zip,
   zip4

--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -9,8 +9,9 @@ const { recordsForReportingPeriod } = require('./records')
 const {
   capitalizeFirstLetter,
   currency,
-  multiselect,
   ec,
+  multiselect,
+  subcategory,
   zip,
   zip4
 } = require('../lib/format')
@@ -73,7 +74,7 @@ async function generateProject111210 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -126,7 +127,7 @@ async function generateProject18 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -173,7 +174,7 @@ async function generateProject19 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -221,7 +222,7 @@ async function generateProject211214 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -276,7 +277,7 @@ async function generateProject2128 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -327,7 +328,7 @@ async function generateProject215218 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -377,7 +378,7 @@ async function generateProject224227 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -424,7 +425,7 @@ async function generateProject236 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -470,7 +471,7 @@ async function generateProject31 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -510,7 +511,7 @@ async function generateProject32 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -551,7 +552,7 @@ async function generateProject4142 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -604,7 +605,7 @@ async function generateProject51518 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -646,7 +647,7 @@ async function generateProject519521 (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
@@ -736,7 +737,7 @@ async function generateProjectBaseline (records) {
           return [
             null, // first col is blank
             ec(record.type),
-            record.subcategory,
+            subcategory(detailedEcCode),
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,

--- a/tests/unit/server/lib/format.spec.js
+++ b/tests/unit/server/lib/format.spec.js
@@ -1,10 +1,12 @@
 import { expect } from 'chai'
 
+import { ecCodes } from '@/server/lib/arpa-ec-codes'
 import {
   capitalizeFirstLetter,
   currency,
-  multiselect,
   ec,
+  multiselect,
+  subcategory,
   zip,
   zip4
 } from '@/server/lib/format'
@@ -95,6 +97,25 @@ describe('server/lib/format', () => {
       expect(multiselect('a,b,c')).to.equal('abc')
       expect(multiselect('a,b;c,d')).to.equal('ab;cd')
       expect(multiselect(',a,b; -c,d')).to.equal('ab;cd')
+    })
+  })
+
+  describe('subcategory', () => {
+    it('handles the null case', () => {
+      expect(subcategory(null)).to.be.null
+      expect(subcategory(undefined)).to.be.undefined
+    })
+    it('handles unknown strings', () => {
+      expect(subcategory('abcdef')).to.be.undefined
+      expect(subcategory('1.0')).to.be.undefined
+    })
+    it('accepts a known subcategory codes', () => {
+      expect(subcategory('1.1')).to.equal('1.1-COVID-19 Vaccination')
+    })
+    it('accepts all known subcategory codes', () => {
+      Object.keys(ecCodes).forEach((code) => {
+        expect(subcategory(code)).not.to.be.undefined
+      })
     })
   })
 


### PR DESCRIPTION
Rewrite all "detailed expenditure category" strings before printing to treasury output.

This ensures that regardless of input template used, we always output the current value expected by treasury.