### PR TITLE
Don't bother validating description of EC codes

### DIFF
--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -53,7 +53,6 @@ async function validateEcCode ({ upload, records }) {
 
   const codeParts = codeString.split('-')
   const code = codeParts[0]
-  const desc = codeParts.slice(1, codeParts.length).join('-')
 
   if (!ecCodes[code]) {
     return new ValidationError(

--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -60,11 +60,6 @@ async function validateEcCode ({ upload, records }) {
       `Record EC code ${code} from entry ${codeString} does not match any known EC code`,
       { tab: 'cover', row: 2, col: 'D', severity: 'err' }
     )
-  } else if (ecCodes[code] !== desc) {
-    return new ValidationError(
-      `Record EC code description "${desc}" for EC code ${code} does not match the expected value "${ecCodes[code]}". This code may need to be updated before submission.`,
-      { tab: 'cover', row: 2, col: 'D', severity: 'warn' }
-    )
   }
 
   // always set EC code if possible; we omit passing the transaction in this


### PR DESCRIPTION
@trumanc I decided to split this off as a distinct PR so we can discuss the right approach separately.

I think it's probably less confusing to agency users to not indicate a warning at all as long as the numeric code matches a known subcategory.  How does that sound?