### PR TITLE
Fix Issue #434: Correct typo where Obligation was incorrectly used twice

### DIFF
--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -803,7 +803,7 @@ async function generateExpendituresLT50000 (records) {
           record.content.Project_Identification_Number__c,
           record.content.Sub_Award_Type_Aggregates_SLFRF__c,
           currency(record.content.Quarterly_Obligation_Amt_Aggregates__c),
-          currency(record.content.Quarterly_Obligation_Amt_Aggregates__c)
+          currency(record.content.Quarterly_Expenditure_Amt_Aggregates__c)
         ]
       default:
         return null
@@ -823,7 +823,7 @@ async function generatePaymentsIndividualsLT50000 (records) {
           null, // first col is blank
           record.content.Project_Identification_Number__c,
           currency(record.content.Quarterly_Obligation_Amt_Aggregates__c),
-          currency(record.content.Quarterly_Obligation_Amt_Aggregates__c)
+          currency(record.content.Quarterly_Expenditure_Amt_Aggregates__c)
         ]
       default:
         return null


### PR DESCRIPTION
Fix for https://github.com/usdigitalresponse/arpa-reporter/issues/434

The obligation field was incorrectly specified twice in a row, instead of giving the obligation and then the expenditures