### PR TITLE
Fix #435: Update EC7 name to new shorter form

### DIFF
--- a/src/server/lib/format.js
+++ b/src/server/lib/format.js
@@ -14,7 +14,7 @@ const EXPENDITURE_CATEGORIES = {
   ec3: '3-Public Health-Negative Economic Impact: Public Sector Capacity',
   ec4: '4-Premium Pay',
   ec5: '5-Infrastructure',
-  ec7: '7-Administrative and Other'
+  ec7: '7-Administrative'
 }
 
 /**


### PR DESCRIPTION
Fix for https://github.com/usdigitalresponse/arpa-reporter/issues/435

Updates the category name provided in the output formatter to the new version as specified in the issue.

I also checked the current bulk upload templates to see if the other categories have changed (they have not).
![Screen Shot 2022-07-14 at 4 39 20 PM](https://user-images.githubusercontent.com/3675290/179118882-048480e8-dcfd-4699-b3be-576dee580cb7.png)
![Screen Shot 2022-07-14 at 4 38 55 PM](https://user-images.githubusercontent.com/3675290/179118885-823ef26d-b13c-4639-b891-9cd301e86328.png)
![Screen Shot 2022-07-14 at 4 36 00 PM](https://user-images.githubusercontent.com/3675290/179118888-7fc8df4f-d504-4af0-b5f1-943b93e85672.png)

