### PR TITLE
Revert "Read project demographics options from dropdowns sheet"

### DIFF
--- a/src/server/services/validation-rules.js
+++ b/src/server/services/validation-rules.js
@@ -33,20 +33,6 @@ function generateRules () {
   rules.awards50k.Primary_Sector__c.listVals = sectors
   rules.ec4.Sectors_Critical_to_Health_Well_Being__c.listVals = sectors
 
-  // Primary_Project_Demographics__c come from dropdowns list
-  // Secondary_Project_Demographics__c come from dropdowns list
-  // Tertiary_Project_Demographics__c come from dropdowns list
-  const projectDemographics = srcDropdowns['Project Demographics']
-  rules.ec1.Primary_Project_Demographics__c = projectDemographics
-  rules.ec1.Secondary_Project_Demographics__c = projectDemographics
-  rules.ec1.Tertiary_Project_Demographics__c = projectDemographics
-  rules.ec2.Primary_Project_Demographics__c = projectDemographics
-  rules.ec2.Secondary_Project_Demographics__c = projectDemographics
-  rules.ec2.Tertiary_Project_Demographics__c = projectDemographics
-  rules.ec7.Primary_Project_Demographics__c = projectDemographics
-  rules.ec7.Secondary_Project_Demographics__c = projectDemographics
-  rules.ec7.Tertiary_Project_Demographics__c = projectDemographics
-
   // value formatters modify the value in the record before it's validated
   // we check any rule against the formatted value
   // for any values we format, we should format them the same way when we export


### PR DESCRIPTION
Reverts usdigitalresponse/arpa-reporter#439


This merge has caused errors on staging. I was able to repro the bug locally, and then fix it by reverting this change. Here's the error message from the logs on staging:

<img width="941" alt="Screen Shot 2022-07-18 at 3 42 13 PM" src="https://user-images.githubusercontent.com/3675290/179629471-abdf9bec-4f4d-4725-a634-7fdd54648c0c.png">
 