### PR TITLE
Format TIN in treasury exports

### DIFF
--- a/src/server/lib/format.js
+++ b/src/server/lib/format.js
@@ -67,6 +67,11 @@ function subcategory (value) {
   return `${value}-${ecCodes[value]}`
 }
 
+function tin (value) {
+  if (value == null) return value
+  return value.toString().replace('-', '')
+}
+
 function zip (value) {
   if (value == null) return value
   return value.toString().padStart(5, '0')
@@ -81,8 +86,9 @@ module.exports = {
   capitalizeFirstLetter,
   currency,
   ec,
-  subcategory,
   multiselect,
+  subcategory,
+  tin,
   zip,
   zip4
 }

--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -12,6 +12,7 @@ const {
   ec,
   multiselect,
   subcategory,
+  tin,
   zip,
   zip4
 } = require('../lib/format')
@@ -838,7 +839,7 @@ async function generateSubaward (records) {
         return [
           null, // first col is blank
           record.content.Recipient_UEI__c,
-          record.content.Recipient_EIN__c,
+          tin(record.content.Recipient_EIN__c),
           record.content.Project_Identification_Number__c,
           record.content.Award_No__c,
           record.content.Award_Type__c,
@@ -873,7 +874,7 @@ async function generateSubRecipient (records, periodId) {
     return [
       null, // first col is blank
       record.Unique_Entity_Identifier__c,
-      record.EIN__c,
+      tin(record.EIN__c),
       record.Name,
       multiselect(record.Entity_Type_2__c),
       record.POC_Email_Address__c,

--- a/tests/unit/server/lib/format.spec.js
+++ b/tests/unit/server/lib/format.spec.js
@@ -7,6 +7,7 @@ import {
   ec,
   multiselect,
   subcategory,
+  tin,
   zip,
   zip4
 } from '@/server/lib/format'
@@ -116,6 +117,22 @@ describe('server/lib/format', () => {
       Object.keys(ecCodes).forEach((code) => {
         expect(subcategory(code)).not.to.be.undefined
       })
+    })
+  })
+
+  describe('tin', () => {
+    it('handles the null case', () => {
+      expect(tin(null)).to.be.null
+      expect(tin(undefined)).to.be.undefined
+    })
+    it('accepts a string', () => {
+      expect(tin('123456789')).to.equal('123456789')
+    })
+    it('accepts a number', () => {
+      expect(tin(123456789)).to.equal('123456789')
+    })
+    it('removes hyphens if present', () => {
+      expect(tin('12-3456789')).to.equal('123456789')
     })
   })
 


### PR DESCRIPTION
This just removes hyphens from the EIN/TIN field.  (I don't know what the difference between an EIN and TIN is. 🤷)

Fixes #462 