### PR TITLE
Ignore hidden sheets when extracting records from uploads

### DIFF
--- a/src/server/services/records.js
+++ b/src/server/services/records.js
@@ -70,6 +70,15 @@ async function recordsForUpload (upload) {
   for (const sheetName of Object.keys(DATA_SHEET_TYPES)) {
     const type = DATA_SHEET_TYPES[sheetName]
     const sheet = workbook.Sheets[sheetName]
+    const sheetAttributes = workbook.Workbook.Sheets.find(
+      sheet => sheet.name === sheetName
+    )
+
+    // ignore hidden sheets
+    console.log(type, sheetAttributes.Hidden)
+    if (sheetAttributes.Hidden !== 0) {
+      continue
+    }
 
     // header is based on the columns we have in the rules
     const header = Object.values(rules[type])


### PR DESCRIPTION
In one RI upload, there are some fields filled out in the EC 2 sheet, even though EC 1 was later selected.

https://ri-arpa-reporter-web.onrender.com/uploads/7566acc4-3485-4ecb-a846-7cf5f39f97fd

The EC 2 sheet is hidden, but we still read it when extracting records from the upload.  This change explicitly ignores hidden sheets, to prevent this from happening in the future.

Fixes #453 