### PR TITLE
Add persistentFormatters and dropdown corrections

### DIFF
--- a/scripts/generateRules.mjs
+++ b/scripts/generateRules.mjs
@@ -10,6 +10,7 @@ import lodash from 'lodash'
 
 import { DATA_SHEET_TYPES, readVersionRecord } from '../src/server/services/records.js'
 import { SERVER_DATA_DIR, EMPTY_TEMPLATE_NAME, SRC_DIR } from '../src/server/environment.js'
+import { dropdownCorrections } from '../src/server/services/validation-rules.js'
 
 const { merge } = lodash
 const log = (msg) => { console.log(chalk.green(msg)) }
@@ -288,6 +289,28 @@ function validateExtractedDropdowns(extractedDropdowns) {
     throw new Error('Correct the dropdownNamesToFieldIds mappings to continue')
   }
 }
+
+function validateDropdownCorrections(extractedDropdowns) {
+  // Make sure that every correction configured refers to a real value in a dropdown somewhere
+  Object.keys(dropdownCorrections).forEach(valToCorrect => {
+    for (const dropdownName in extractedDropdowns) {
+      for (const dropdownValue of extractedDropdowns[dropdownName]) {
+        if (valToCorrect == dropdownValue) {
+          return
+        }
+      }
+    }
+    // Didn't find the value anywhere? Throw an error to force us to correct it
+    
+    // Getting this error?
+    // Did you recently add a new correction or update the worksheet?
+    // Check to make sure the key in dropdownCorrections exactly matches the key *currently* in
+    // the worksheet.
+    console.log(chalk.red(
+      `Error: correction for dropdown value ${valToCorrect} doesn't reference a real value.`))
+      throw new Error('Fix the dropdownCorrections configuration to continue.')
+  })
+}
 const run = async () => {
   log(`extracting rules from ${EMPTY_TEMPLATE_NAME}...`)
 
@@ -299,6 +322,7 @@ const run = async () => {
   const dropdowns = await extractDropdowns(workbook)
   validateExtractedDropdowns(dropdowns)
   await saveTo('templateDropdowns.json', dropdowns)
+  validateDropdownCorrections(dropdowns)
 
   const rules = await extractRules(workbook, logic, dropdowns)
   await saveTo('templateRules.json', rules)

--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -179,6 +179,7 @@ async function generateProject19 (records) {
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
+            record.content.Cancellation_Reason__c,
             currency(record.content.Adopted_Budget__c),
             currency(record.content.Total_Obligations__c),
             currency(record.content.Total_Expenditures__c),

--- a/src/server/services/records.js
+++ b/src/server/services/records.js
@@ -80,8 +80,9 @@ async function recordsForUpload (upload) {
       continue
     }
 
+    const typeRules = rules[type]
     // header is based on the columns we have in the rules
-    const header = Object.values(rules[type])
+    const header = Object.values(typeRules)
       .sort((a, b) => a.index - b.index)
       .map(rule => rule.key)
 
@@ -102,7 +103,19 @@ async function recordsForUpload (upload) {
 
     // each row in the input sheet becomes a unique record
     for (const row of rows) {
-      records.push({ type, subcategory, upload, content: row })
+      const formattedRow = {}
+      Object.keys(row).forEach(fieldId => {
+        let value = row[fieldId]
+        for (const formatter of typeRules[fieldId].persistentFormatters) {
+          try {
+            value = formatter(value)
+          } catch (e) {
+            console.log(`Persistent formatter failed to format value ${value} with error:`, e)
+          }
+        }
+        formattedRow[fieldId] = value
+      })
+      records.push({ type, subcategory, upload, content: formattedRow })
     }
   }
 

--- a/src/server/services/records.js
+++ b/src/server/services/records.js
@@ -80,9 +80,9 @@ async function recordsForUpload (upload) {
       continue
     }
 
-    const typeRules = rules[type]
+    const rulesForCurrentType = rules[type]
     // header is based on the columns we have in the rules
-    const header = Object.values(typeRules)
+    const header = Object.values(rulesForCurrentType)
       .sort((a, b) => a.index - b.index)
       .map(rule => rule.key)
 
@@ -106,7 +106,7 @@ async function recordsForUpload (upload) {
       const formattedRow = {}
       Object.keys(row).forEach(fieldId => {
         let value = row[fieldId]
-        for (const formatter of typeRules[fieldId].persistentFormatters) {
+        for (const formatter of rulesForCurrentType[fieldId].persistentFormatters) {
           try {
             value = formatter(value)
           } catch (e) {

--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -237,7 +237,7 @@ async function validateRecord ({ upload, record, typeRules: rules }) {
       // how do we format the value before checking it?
       let value = record[key]
       let formatFailures = 0
-      for (const formatter of rule.valueFormatters) {
+      for (const formatter of rule.validationFormatters) {
         try {
           value = formatter(value)
         } catch (e) {

--- a/src/server/services/validation-rules.js
+++ b/src/server/services/validation-rules.js
@@ -3,7 +3,7 @@ const srcRules = require('../lib/templateRules.json')
 
 const recordValueFormatters = {
   makeString: (val) => String(val),
-  trimWhitespace: (val) => val.trim(),
+  trimWhitespace: (val) => val ? val.trim() : val,
   removeCommas: (val) => val.replace(/,/g, ''),
   removeSepDashes: (val) => val.replace(/^-/, '').replace(/;\s*-/g, ';'),
   toLowerCase: (val) => val.toLowerCase()
@@ -12,7 +12,7 @@ const recordValueFormatters = {
 /*
 Structured data recording all the immediate corrections we want to apply to dropdowns.
 There are 2 types of corrections we can apply:
-1) The value in the current worksheet is incorrect.
+1) The value in the currently committed input template is incorrect.
 2) A value in the dropdown list changed in the past, and we want to continue to allow legacy vals as valid inputs.
 In the first case, we will alter the validation rule to check against the new correct value, and
 then treat the value currently seen in the worksheet as an allowable legacy value.
@@ -61,7 +61,7 @@ function generateRules () {
 
       if (rule.dataType === 'String') {
         rule.validationFormatters.push(recordValueFormatters.makeString)
-        rule.validationFormatters.push(recordValueFormatters.trimWhitespace)
+        rule.persistentFormatters.push(recordValueFormatters.trimWhitespace)
       }
 
       if (rule.dataType === 'Multi-Select') {


### PR DESCRIPTION
Adds two new systems:
1) a new system for doing value formatting. These validations are more powerful (and dangerous) than the previous formatting, because they will also affect the values that are printed to exports.

2) A structured system for recording problems we've detected with dropdown values. It lets us easily refer to a specific value in the worksheet, and provide information about what that value should be corrected to, and what other values we should allow. This system uses the new formatting system to coerce any allowable values into the correct one.

(also fixes a bug I found where 1.9 projects were not exporting the cancellation reason)

Here are some output csvs, shown pre-fix and post-fix to show how the output dropdown values were fixed. Both cases used the same input uploads, which included the old dropdown values as their value.
The post-fix export csvs correctly show the new dropdown values, with their newly enforced commas and space.

Projects:
<img width="1367" alt="Screen Shot 2022-07-23 at 1 40 52 PM" src="https://user-images.githubusercontent.com/3675290/180622872-f5ead8f8-6cf9-447a-a653-5a0ec071a5e6.png">


Awards:
<img width="1188" alt="Screen Shot 2022-07-23 at 1 42 37 PM" src="https://user-images.githubusercontent.com/3675290/180622879-caf3ef00-bdfe-47aa-b29e-091293c4e795.png">
 