### PR TITLE
Adopt AsyncLocalStorage to manage tenant_id

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "adm-zip": "0.5.9",
     "aws-sdk": "^2.963.0",
-    "body-parser": "^1.19.0",
+    "body-parser": "^1.20.0",
     "bootstrap": "^4.6.1",
     "connect-history-api-fallback": "^1.6.0",
     "cookie-parser": "^1.4.5",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "pg": "^8.7.1",
     "pg-types": "4.0.0",
     "popper.js": "1.16.1",
+    "ts-invariant": "0.10.3",
     "uuid": "^8.3.2",
     "vue": "^2.7.2",
     "vue-good-table": "^2.21.11",

--- a/src/server/db/agencies.js
+++ b/src/server/db/agencies.js
@@ -1,14 +1,15 @@
 
 const knex = require('./connection')
 const { requiredArgument } = require('../lib/preconditions')
+const { useTenantId } = require('../use-request')
 
 function baseQuery (trns) {
   return trns('agencies')
     .select('*')
 }
 
-function agencies (tenantId, trns = knex) {
-  requiredArgument(tenantId, 'must specify tenantId to list agencies')
+function agencies (trns = knex) {
+  const tenantId = useTenantId()
 
   return baseQuery(trns)
     .where('tenant_id', tenantId)
@@ -21,9 +22,9 @@ function agencyById (id, trns = knex) {
     .then(r => r[0])
 }
 
-function agencyByCode (tenantId, code, trns = knex) {
-  requiredArgument(tenantId, 'must specify tenantId in agencyByCode')
+function agencyByCode (code, trns = knex) {
   requiredArgument(code, 'must specify code in agencyByCode')
+  const tenantId = useTenantId()
 
   return baseQuery(trns)
     .select('*')
@@ -31,10 +32,10 @@ function agencyByCode (tenantId, code, trns = knex) {
 }
 
 function createAgency (agency, trns = knex) {
-  requiredArgument(agency.tenant_id, 'must specify tenantId to create new agency')
+  const tenantId = useTenantId()
 
   return trns
-    .insert(agency)
+    .insert({ ...agency, tenant_id: tenantId })
     .into('agencies')
     .returning('*')
     .then(r => r[0])

--- a/src/server/db/settings.js
+++ b/src/server/db/settings.js
@@ -1,8 +1,9 @@
 const knex = require('./connection')
 const { requiredArgument } = require('../lib/preconditions')
+const { useTenantId } = require('../use-request')
 
-function setCurrentReportingPeriod (tenantId, id, trns = knex) {
-  requiredArgument(tenantId, 'must specify tenantId')
+function setCurrentReportingPeriod (id, trns = knex) {
+  const tenantId = useTenantId()
   requiredArgument(id, 'must specify id in setCurrentReportingPeriod')
 
   return trns('application_settings')
@@ -10,8 +11,8 @@ function setCurrentReportingPeriod (tenantId, id, trns = knex) {
     .update('current_reporting_period_id', id)
 }
 
-async function getCurrentReportingPeriodID (tenantId, trns = knex) {
-  requiredArgument(tenantId, 'must specify tenantId')
+async function getCurrentReportingPeriodID (trns = knex) {
+  const tenantId = useTenantId()
 
   return trns('application_settings')
     .select('*')
@@ -19,8 +20,8 @@ async function getCurrentReportingPeriodID (tenantId, trns = knex) {
     .then(r => r[0].current_reporting_period_id)
 }
 
-async function applicationSettings (tenantId, trns = knex) {
-  requiredArgument(tenantId, 'must specify tenantId')
+async function applicationSettings (trns = knex) {
+  const tenantId = useTenantId()
 
   return await trns('application_settings')
     .join(

--- a/src/server/db/users.js
+++ b/src/server/db/users.js
@@ -1,11 +1,11 @@
 const { v4 } = require('uuid')
 
 const knex = require('./connection')
-const { requiredArgument } = require('../lib/preconditions')
 const environment = require('../environment')
+const { useTenantId } = require('../use-request')
 
-function users (tenantId, trns = knex) {
-  requiredArgument(tenantId, 'must specify tenantId when querying user list')
+function users (trns = knex) {
+  const tenantId = useTenantId()
 
   return trns('users')
     .leftJoin('agencies', 'users.agency_id', 'agencies.id')
@@ -15,10 +15,10 @@ function users (tenantId, trns = knex) {
 }
 
 function createUser (user, trns = knex) {
-  requiredArgument(user.tenant_id, "can't create user without specifying tenant_id")
+  const tenantId = useTenantId()
 
   return trns('users')
-    .insert(user)
+    .insert({ ...user, tenant_id: tenantId })
     .returning('*')
     .then(rows => rows[0])
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -4,12 +4,16 @@ const express = require('express')
 // handled. It just calls next(err) with them.
 require('express-async-errors')
 
+const { requestProviderMiddleware } = require('./use-request')
 const configureAPI = require('./configure')
 const environment = require('./environment')
 
 console.log(`Database is ${environment.POSTGRES_URL}`)
 
 const app = express()
+
+app.use(requestProviderMiddleware)
+
 configureAPI(app)
 
 app.listen(

--- a/src/server/lib/ensure-async-context.js
+++ b/src/server/lib/ensure-async-context.js
@@ -1,0 +1,36 @@
+const { AsyncResource } = require('node:async_hooks')
+
+/**
+ * Ensure that an express middleware respects async local storage context.
+ *
+ * Accepts an express middleware and returns a copy of that middleware with the
+ * next() call explicitly bound to the current AsyncResource context.
+ *
+ * When working with native promises or async/await syntax, Node can
+ * automatically forward any existing async resource to nested async or promise
+ * invocations. However, when working with nested callback-passing patterns
+ * (such as occurs in an express middleware stack) Node cannot know whether the
+ * function being passed around should be bound to the current resource.
+ *
+ * Express may update their plugin architecture to resolve this in a future
+ * version. Middleware developers can also update their implementations to
+ * ensure backward-compatible support for AsyncLocalStorage. This function
+ * allows us to work around the issue for current versions of express and
+ * plugins that have not yet been updated.
+ *
+ * @example
+ * router.post(
+ *   '/upload',
+ *   ensureAsyncContext(asyncMiddleware),
+ *   async (req, res, next) => {
+ *     // ...
+ *   },
+ * );
+ */
+function ensureAsyncContext (middleware) {
+  return (req, res, next) => middleware(req, res, AsyncResource.bind(next))
+}
+
+module.exports = {
+  ensureAsyncContext
+}

--- a/src/server/routes/agencies.js
+++ b/src/server/routes/agencies.js
@@ -10,7 +10,7 @@ const {
 } = require('../db/agencies')
 
 router.get('/', requireUser, function (req, res) {
-  agencies(req.session.user.tenant_id).then(agencies => res.json({ agencies }))
+  agencies().then(agencies => res.json({ agencies }))
 })
 
 async function validateAgency (agency) {
@@ -43,10 +43,7 @@ router.post('/', requireAdminUser, async function (req, res, next) {
       const agency = await updateAgency(agencyInfo)
       res.json({ agency })
     } else {
-      const agency = await createAgency({
-        ...agencyInfo,
-        tenant_id: req.session.user.tenant_id
-      })
+      const agency = await createAgency(agencyInfo)
       res.json({ agency })
     }
   } catch (e) {

--- a/src/server/routes/application_settings.js
+++ b/src/server/routes/application_settings.js
@@ -7,7 +7,7 @@ const { applicationSettings } = require('../db/settings')
 const { requireUser } = require('../access-helpers')
 
 router.get('/', requireUser, async function (req, res) {
-  const application_settings = await applicationSettings(req.session.user.tenant_id)
+  const application_settings = await applicationSettings()
   res.json({ application_settings })
 })
 

--- a/src/server/routes/audit-report.js
+++ b/src/server/routes/audit-report.js
@@ -11,7 +11,7 @@ router.get('/', requireUser, async function (req, res) {
 
   let report
   try {
-    report = await generate(req.session.user.tenant_id, req.headers.host)
+    report = await generate(req.headers.host)
   } catch (error) {
     return res.status(500).send(error.message)
   }

--- a/src/server/routes/exports.js
+++ b/src/server/routes/exports.js
@@ -7,14 +7,13 @@ const arpa = require('../services/generate-arpa-report')
 const { getReportingPeriodID, getReportingPeriod } = require('../db/reporting-periods')
 
 router.get('/', requireUser, async function (req, res) {
-  const tenantId = req.session.user.tenant_id
-  const periodId = await getReportingPeriodID(tenantId, req.query.period_id)
-  const period = await getReportingPeriod(tenantId, periodId)
+  const periodId = await getReportingPeriodID(req.query.period_id)
+  const period = await getReportingPeriod(periodId)
   if (!period) {
     return res.status(404).json({ error: 'invalid reporting period' })
   }
 
-  const report = await arpa.generateReport(tenantId, periodId)
+  const report = await arpa.generateReport(periodId)
 
   if (_.isError(report)) {
     return res.status(500).send(report.message)

--- a/src/server/routes/subrecipients.js
+++ b/src/server/routes/subrecipients.js
@@ -8,7 +8,7 @@ const { listRecipients, getRecipient, updateRecipient } = require('../db/arpa-su
 const { getRules } = require('../services/validation-rules')
 
 router.get('/', requireUser, async function (req, res) {
-  const recipients = await listRecipients(req.session.user.tenant_id)
+  const recipients = await listRecipients()
   return res.json({ recipients })
 })
 

--- a/src/server/routes/uploads.js
+++ b/src/server/routes/uploads.js
@@ -18,9 +18,8 @@ const { validateUpload } = require('../services/validate-upload')
 const ValidationError = require('../lib/validation-error')
 
 router.get('/', requireUser, async function (req, res) {
-  const tenantId = req.session.user.tenant_id
-  const periodId = await getReportingPeriodID(tenantId, req.query.period_id)
-  const uploads = await uploadsInPeriod(tenantId, periodId)
+  const periodId = await getReportingPeriodID(req.query.period_id)
+  const uploads = await uploadsInPeriod(periodId)
   return res.json({ uploads })
 })
 
@@ -73,7 +72,7 @@ router.get('/:id/series', requireUser, async (req, res) => {
     series = [upload]
   }
 
-  const allExported = await usedForTreasuryExport(upload.tenant_id, upload.reporting_period_id)
+  const allExported = await usedForTreasuryExport(upload.reporting_period_id)
   const seriesExported = allExported.find(upl => (upl.agency_id === upload.agency_id && upl.ec_code === upload.ec_code))
 
   res.json({

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -33,7 +33,7 @@ async function validateUser (user, creator) {
 }
 
 router.get('/', requireUser, async function (req, res, next) {
-  const allUsers = await listUsers(req.session.user.tenant_id)
+  const allUsers = await listUsers()
   const curUser = allUsers.find(u => u.id === Number(req.signedCookies.userId))
 
   const users = (curUser.role === 'admin') ? allUsers : [curUser]
@@ -64,10 +64,7 @@ router.post('/', requireAdminUser, async function (req, res, next) {
       const updatedUser = await updateUser(user)
       res.json({ user: updatedUser })
     } else {
-      const updatedUser = await createUser({
-        ...user,
-        tenant_id: creator.tenant_id
-      })
+      const updatedUser = await createUser(user)
       res.json({ user: updatedUser })
 
       void sendWelcomeEmail(updatedUser.email, req.headers.origin)

--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -47,9 +47,9 @@ function isProjectRecord (record) {
   ].includes(record.type)
 }
 
-async function generateReportName (tenantId, periodId) {
+async function generateReportName (periodId) {
   const now = moment().utc()
-  const { title: state } = await applicationSettings(tenantId)
+  const { title: state } = await applicationSettings()
 
   const filename = [
     state.replace(/ /g, '-'),
@@ -904,10 +904,9 @@ async function generateSubRecipient (records, periodId) {
   })
 }
 
-async function generateReport (tenantId, periodId) {
-  requiredArgument(tenantId, 'must specify tenantId')
+async function generateReport (periodId) {
   requiredArgument(periodId, 'must specify periodId')
-  const records = await recordsForReportingPeriod(tenantId, periodId)
+  const records = await recordsForReportingPeriod(periodId)
 
   // generate every csv file for the report
   const csvObjects = [
@@ -974,7 +973,7 @@ async function generateReport (tenantId, periodId) {
     zip.addFile(name + '.csv', buffer)
   })
 
-  const reportNamePromise = generateReportName(tenantId, periodId)
+  const reportNamePromise = generateReportName(periodId)
 
   const [reportName] = await Promise.all([
     reportNamePromise,

--- a/src/server/services/get-template.js
+++ b/src/server/services/get-template.js
@@ -23,13 +23,12 @@ function periodTemplatePath (reportingPeriod) {
   )
 }
 
-async function savePeriodTemplate (tenantId, periodId, fileName, buffer) {
-  requiredArgument(tenantId, 'must specify tenantId in savePeriodTemplate')
+async function savePeriodTemplate (periodId, fileName, buffer) {
   requiredArgument(periodId, 'must specify periodId in savePeriodTemplate')
   requiredArgument(fileName, 'must specify fileName in savePeriodTemplate')
   requiredArgument(buffer, 'must specify buffer in savePeriodTemplate')
 
-  const reportingPeriod = await getReportingPeriod(tenantId, periodId)
+  const reportingPeriod = await getReportingPeriod(periodId)
 
   await mkdir(PERIOD_TEMPLATES_DIR, { recursive: true })
   await writeFile(
@@ -67,11 +66,10 @@ async function loadTemplate (templateName) {
   return xlsx.utils.sheet_to_json(worksheet, { header: 1, blankrows: false })
 }
 
-async function templateForPeriod (tenantId, periodId) {
-  requiredArgument(tenantId, 'must specify tenantId in templateForPeriod')
+async function templateForPeriod (periodId) {
   requiredArgument(periodId, 'must specify periodId in templateForPeriod')
 
-  const reportingPeriod = await getReportingPeriod(tenantId, periodId)
+  const reportingPeriod = await getReportingPeriod(periodId)
 
   if (reportingPeriod.template_filename) {
     const filename = reportingPeriod.template_filename

--- a/src/server/services/persist-upload.js
+++ b/src/server/services/persist-upload.js
@@ -24,14 +24,13 @@ async function persistUpload ({ filename, user, buffer }) {
   }
 
   // get the current reporting period
-  const reportingPeriod = await getReportingPeriod(user.tenant_id)
+  const reportingPeriod = await getReportingPeriod()
 
   // create an upload
   const uploadRow = {
     filename: path.basename(filename),
     reporting_period_id: reportingPeriod.id,
-    user_id: user.id,
-    tenant_id: user.tenant_id
+    user_id: user.id
   }
   const upload = await createUpload(uploadRow)
 

--- a/src/server/services/records.js
+++ b/src/server/services/records.js
@@ -126,12 +126,11 @@ async function recordsForUpload (upload) {
   return records
 }
 
-async function recordsForReportingPeriod (tenantId, periodId) {
+async function recordsForReportingPeriod (periodId) {
   log('recordsForReportingPeriod()')
-  requiredArgument(tenantId, 'must specify tenantId in recordsForReportingPeriod')
   requiredArgument(periodId, 'must specify periodId in recordsForReportingPeriod')
 
-  const uploads = await usedForTreasuryExport(tenantId, periodId)
+  const uploads = await usedForTreasuryExport(periodId)
   const groupedRecords = await Promise.all(
     uploads.map(upload => recordsForUpload(upload))
   )
@@ -142,16 +141,15 @@ async function recordsForReportingPeriod (tenantId, periodId) {
  * Get the most recent, validated record for each unique project, as of the
  * specified reporting period.
 */
-async function mostRecentProjectRecords (tenantId, periodId) {
+async function mostRecentProjectRecords (periodId) {
   log('mostRecentProjectRecords()')
-  requiredArgument(tenantId, 'must specify tenantId in mostRecentProjectRecords')
   requiredArgument(periodId, 'must specify periodId in mostRecentProjectRecords')
 
-  const reportingPeriods = await getPreviousReportingPeriods(tenantId, periodId)
+  const reportingPeriods = await getPreviousReportingPeriods(periodId)
 
   const allRecords = await Promise.all(
     reportingPeriods.map(reportingPeriod =>
-      recordsForReportingPeriod(tenantId, reportingPeriod.id)
+      recordsForReportingPeriod(reportingPeriod.id)
     )
   )
 

--- a/src/server/services/revalidate-uploads.js
+++ b/src/server/services/revalidate-uploads.js
@@ -2,7 +2,7 @@ const { validateUpload } = require('./validate-upload')
 const { uploadsInPeriod } = require('../db/uploads')
 
 async function revalidateUploads (period, user, trns) {
-  const uploads = await uploadsInPeriod(user.tenant_id, period.id, trns)
+  const uploads = await uploadsInPeriod(period.id, trns)
 
   const updates = []
   for (const upload of uploads) {

--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -24,7 +24,7 @@ async function validateAgencyId ({ upload, records, trns }) {
   }
 
   // must exist in the db
-  const matchingAgency = (await agencyByCode(upload.tenant_id, agencyCode, trns))[0]
+  const matchingAgency = (await agencyByCode(agencyCode, trns))[0]
   if (!matchingAgency) {
     return new ValidationError(
       `Agency code ${agencyCode} does not match any known agency`,
@@ -96,7 +96,7 @@ async function validateVersion ({ records, rules }) {
 }
 
 async function validateReportingPeriod ({ upload, records, trns }) {
-  const uploadPeriod = await getReportingPeriod(upload.tenant_id, upload.reporting_period_id, trns)
+  const uploadPeriod = await getReportingPeriod(upload.reporting_period_id, trns)
   const coverSheet = records.find(record => record.type === 'cover').content
   const errors = []
 
@@ -135,12 +135,12 @@ async function validateSubrecipientRecord ({ upload, record: recipient, typeRule
   // does the row already exist?
   let byUei = null
   if (recipient.Unique_Entity_Identifier__c) {
-    byUei = await findRecipient(upload.tenant_id, recipient.Unique_Entity_Identifier__c, null, trns)
+    byUei = await findRecipient(recipient.Unique_Entity_Identifier__c, null, trns)
   }
 
   let byTin = null
   if (recipient.EIN__c) {
-    byTin = await findRecipient(upload.tenant_id, null, recipient.EIN__c, trns)
+    byTin = await findRecipient(null, recipient.EIN__c, trns)
   }
 
   // did we find two different subrecipients?
@@ -200,8 +200,7 @@ async function validateSubrecipientRecord ({ upload, record: recipient, typeRule
         uei: recipient.Unique_Entity_Identifier__c,
         tin: recipient.EIN__c,
         record: recipient,
-        upload_id: upload.id,
-        tenant_id: upload.tenant_id
+        upload_id: upload.id
       }
       await createRecipient(dbRow, trns)
     }

--- a/src/server/use-request.js
+++ b/src/server/use-request.js
@@ -1,0 +1,24 @@
+const { AsyncLocalStorage } = require('node:async_hooks')
+
+const requestStorage = new AsyncLocalStorage()
+
+/**
+ * An express middleware. Captures the request in AsyncLocalStorage for later
+ * retrieval.
+ */
+function requestProviderMiddleware (req, res, next) {
+  requestStorage.run(req, next)
+}
+
+/**
+ * Get the request object currently being handled by express.
+ * @returns {Request}
+ */
+function useRequest () {
+  return requestStorage.getStore()
+}
+
+module.exports = {
+  requestProviderMiddleware,
+  useRequest
+}

--- a/src/server/use-request.js
+++ b/src/server/use-request.js
@@ -18,7 +18,13 @@ function useRequest () {
   return requestStorage.getStore()
 }
 
+/** A shortcut helper to get at tenant_id directly */
+function useTenantId () {
+  return useRequest().session.user.tenant_id
+}
+
 module.exports = {
   requestProviderMiddleware,
-  useRequest
+  useRequest,
+  useTenantId
 }

--- a/src/server/use-request.js
+++ b/src/server/use-request.js
@@ -1,5 +1,7 @@
 const { AsyncLocalStorage } = require('node:async_hooks')
 
+const { invariant } = require('ts-invariant')
+
 const requestStorage = new AsyncLocalStorage()
 
 /**
@@ -18,9 +20,23 @@ function useRequest () {
   return requestStorage.getStore()
 }
 
+function useSession () {
+  const session = useRequest().session
+  invariant(session != null, 'You called useSession, but a session was not available. Consider specifying requireUser on the affected route.')
+  return session
+}
+
+function useUser () {
+  const user = useSession().user
+  invariant(user != null, 'You called useUser, but a user was not found. Consider specifying requireUser on the affected route.')
+  return user
+}
+
 /** A shortcut helper to get at tenant_id directly */
 function useTenantId () {
-  return useRequest().session.user.tenant_id
+  const tenantId = useUser().tenant_id
+  invariant(tenantId != null, 'You called useTenantId, but a tenantId was not found.')
+  return tenantId
 }
 
 module.exports = {

--- a/tests/server/db/reporting-periods.spec.js
+++ b/tests/server/db/reporting-periods.spec.js
@@ -25,6 +25,7 @@
 const { getAllReportingPeriods, getReportingPeriod } = requireSrc(__filename)
 const assert = require('assert')
 const _ = require('lodash')
+const { withTenantId } = require('../helpers/with-tenant-id')
 
 const TENANT_A = 0
 const TENANT_B = 1
@@ -33,19 +34,19 @@ const NONEXISTENT_TENANT = 100
 describe('db/reporting-periods.js', function () {
   describe('getAll', function () {
     it('Returns a list of reporting periods', async function () {
-      const result = await getAllReportingPeriods(TENANT_A)
+      const result = await withTenantId(TENANT_A, getAllReportingPeriods)
       assert.equal(result.length, 21)
     })
 
     it('Only returns reporting periods for the specified tenant', async function () {
-      const nonexistent = await getAllReportingPeriods(NONEXISTENT_TENANT)
+      const nonexistent = await withTenantId(NONEXISTENT_TENANT, getAllReportingPeriods)
       assert.equal(nonexistent.length, 0)
 
-      const a = await getAllReportingPeriods(TENANT_A)
-      const b = await getAllReportingPeriods(TENANT_B)
+      const a = await withTenantId(TENANT_A, getAllReportingPeriods)
+      const b = await withTenantId(TENANT_B, getAllReportingPeriods)
+
       assert.equal(a.length, 21)
       assert.equal(b.length, 21)
-
       const allIds = _.chain([a, b]).flatten().map('id').uniq().value()
       assert.equal(allIds.length, 42)
     })
@@ -54,29 +55,31 @@ describe('db/reporting-periods.js', function () {
   describe('get', function () {
     describe('when a specific id is passed', function () {
       it('Returns that reporting period', async function () {
-        const result = await getReportingPeriod(TENANT_A, 2)
+        const result = await withTenantId(TENANT_A, () => getReportingPeriod(2))
         assert.equal(result.id, 2)
       })
 
       it('Doesn\'t return a reporting period with mismatched tenant', async function () {
-        assert.equal((await getReportingPeriod(TENANT_B, 2)), null)
+        assert.equal((await withTenantId(TENANT_B, () => getReportingPeriod(2))), null)
       })
     })
 
     describe('when an invalid id is passed', function () {
       it('returns null', async function () {
-        assert.equal((await getReportingPeriod(TENANT_A, '')), null)
-        assert.equal((await getReportingPeriod(TENANT_A, null)), null)
-        assert.equal((await getReportingPeriod(TENANT_A, 12356)), null)
+        await withTenantId(TENANT_A, async () => {
+          assert.equal((await getReportingPeriod('')), null)
+          assert.equal((await getReportingPeriod(null)), null)
+          assert.equal((await getReportingPeriod(12356)), null)
+        })
       })
     })
 
     it('returns the current reporting period', async function () {
-      const a = await getReportingPeriod(TENANT_A)
+      const a = await withTenantId(TENANT_A, getReportingPeriod)
       assert.equal(a.id, 1)
       assert.equal(a.name, 'Quarterly 1')
 
-      const b = await getReportingPeriod(TENANT_B)
+      const b = await withTenantId(TENANT_B, getReportingPeriod)
       assert.equal(b.id, 22)
       assert.equal(b.name, 'Quarterly 1')
     })

--- a/tests/server/db/settings.spec.js
+++ b/tests/server/db/settings.spec.js
@@ -1,6 +1,7 @@
 
 const settings = requireSrc(__filename)
 const assert = require('assert')
+const { withTenantId } = require('../helpers/with-tenant-id')
 
 const TENANT_A = 0
 const TENANT_B = 1
@@ -8,11 +9,11 @@ const TENANT_B = 1
 describe('application settings db', function () {
   describe('applicationSettings', function () {
     it('Returns the current reporting period & title', async () => {
-      const a = await settings.applicationSettings(TENANT_A)
+      const a = await withTenantId(TENANT_A, settings.applicationSettings)
       assert.equal(a.current_reporting_period_id, 1)
       assert.equal(a.title, 'Rhode Island')
 
-      const b = await settings.applicationSettings(TENANT_B)
+      const b = await withTenantId(TENANT_B, settings.applicationSettings)
       assert.equal(b.current_reporting_period_id, 22)
       assert.equal(b.title, 'California')
     })
@@ -22,28 +23,30 @@ describe('application settings db', function () {
     let savedReportingPeriod
 
     beforeEach('save current period', async function () {
-      const curr = await settings.applicationSettings(TENANT_A)
+      const curr = await withTenantId(TENANT_A, settings.applicationSettings)
       savedReportingPeriod = curr.current_reporting_period_id
     })
 
     afterEach('restore reporting period', async function () {
-      await settings.setCurrentReportingPeriod(TENANT_A, savedReportingPeriod)
+      await withTenantId(TENANT_A, () => settings.setCurrentReportingPeriod(savedReportingPeriod))
     })
 
     it('Changes the current reporting period', async () => {
-      await settings.setCurrentReportingPeriod(TENANT_A, 2)
+      await withTenantId(TENANT_A, async () => {
+        await settings.setCurrentReportingPeriod(2)
 
-      const result = await settings.applicationSettings(TENANT_A)
-      assert.equal(result.current_reporting_period_id, 2)
+        const result = await settings.applicationSettings()
+        assert.equal(result.current_reporting_period_id, 2)
+      })
     })
 
     it('Only changes the current reporting period for the specified tenant', async () => {
-      await settings.setCurrentReportingPeriod(TENANT_A, 2)
+      await withTenantId(TENANT_A, () => settings.setCurrentReportingPeriod(2))
 
-      const a = await settings.applicationSettings(TENANT_A)
+      const a = await withTenantId(TENANT_A, settings.applicationSettings)
       assert.equal(a.current_reporting_period_id, 2)
 
-      const b = await settings.applicationSettings(TENANT_B)
+      const b = await withTenantId(TENANT_B, settings.applicationSettings)
       assert.equal(b.current_reporting_period_id, 22)
     })
   })

--- a/tests/server/db/uploads.spec.js
+++ b/tests/server/db/uploads.spec.js
@@ -1,16 +1,16 @@
 
 const uploads = requireSrc(__filename)
 const assert = require('assert')
+const { withTenantId } = require('../helpers/with-tenant-id')
 const { knex } = require('../mocha_init')
+
+const TENANT_ID = 0
 
 describe('db/uploads.js', function () {
   let upload
 
   beforeEach('init an upload row', async function () {
-    upload = {
-      filename: 'filename',
-      tenant_id: 0
-    }
+    upload = { filename: 'filename' }
   })
 
   describe('createUpload', function () {
@@ -19,27 +19,27 @@ describe('db/uploads.js', function () {
     })
 
     it('Returns the resulting row', async function () {
-      const inserted = await uploads.createUpload(upload)
+      const inserted = await withTenantId(TENANT_ID, () => uploads.createUpload(upload))
       assert.ok(inserted)
       assert.equal(inserted.filename, 'filename')
     })
 
     it('Requires a filename', async function () {
       upload.filename = null
-      assert.rejects(async () => await uploads.createUpload(upload))
+      assert.rejects(async () => await withTenantId(TENANT_ID, () => uploads.createUpload(upload)))
     })
 
     describe('when there is invalid user id', function () {
       it('throws an error', async function () {
         upload.user_id = 12345
-        assert.rejects(async () => await uploads.createUpload(upload))
+        assert.rejects(async () => await withTenantId(TENANT_ID, uploads.createUpload(upload)))
       })
     })
 
     describe('when there is invalid reporting period', function () {
       it('throws an error', async function () {
         upload.reporting_period_id = 12345
-        assert.rejects(async () => await uploads.createUpload(upload))
+        assert.rejects(async () => await withTenantId(TENANT_ID, uploads.createUpload(upload)))
       })
     })
   })

--- a/tests/server/helpers/with-tenant-id.js
+++ b/tests/server/helpers/with-tenant-id.js
@@ -1,0 +1,23 @@
+const { requestProviderMiddleware } = require('../../../src/server/use-request')
+
+/**
+ * Runs a callback function in the context of an AsyncLocalStorage store
+ * containing the supplied teant_id.
+ * @param {string} tenantId
+ * @param {Function} callback
+ * @returns {Promise}
+ * A promise that resolves to the return value of the callback, if any.
+ */
+async function withTenantId (tenantId, callback) {
+  return new Promise(resolve => {
+    requestProviderMiddleware(
+      { session: { user: { tenant_id: tenantId } } },
+      null,
+      () => resolve(callback())
+    )
+  })
+}
+
+module.exports = {
+  withTenantId
+}

--- a/tests/server/helpers/with-tenant-id.js
+++ b/tests/server/helpers/with-tenant-id.js
@@ -2,7 +2,7 @@ const { requestProviderMiddleware } = require('../../../src/server/use-request')
 
 /**
  * Runs a callback function in the context of an AsyncLocalStorage store
- * containing the supplied teant_id.
+ * containing the supplied tenant_id.
  * @param {string} tenantId
  * @param {Function} callback
  * @returns {Promise}

--- a/tests/server/routes/route_test_helpers.js
+++ b/tests/server/routes/route_test_helpers.js
@@ -6,6 +6,7 @@ const supertest = require('supertest')
 const { sign: signCookie } = require('cookie-signature')
 
 const configureAPI = requireSrc(path.resolve(__dirname, '../configure'))
+const { requestProviderMiddleware } = require('../../../src/server/use-request')
 const { knex } = require('../mocha_init')
 
 async function getSessionCookie (userIdOrEmail) {
@@ -30,6 +31,7 @@ async function getSessionCookie (userIdOrEmail) {
 
 function makeTestServer () {
   const app = express()
+  app.use(requestProviderMiddleware)
   configureAPI(app, {
     // The normal request logging from Morgan just clutters Mocha's test runner output
     disableRequestLogging: true

--- a/tests/server/services/generate-arpa-report.spec.js
+++ b/tests/server/services/generate-arpa-report.spec.js
@@ -1,11 +1,12 @@
 const assert = require('assert')
 
-const arpa = require('../../../src/server/services/generate-arpa-report')
+const { generateReport } = require('../../../src/server/services/generate-arpa-report')
+const { withTenantId } = require('../helpers/with-tenant-id')
 
 describe('arpa report generation', function () {
   it('generates a report', async function () {
     const tenantId = 0
-    const report = await arpa.generateReport(tenantId, 1)
+    const report = await withTenantId(tenantId, () => generateReport(1))
     assert.ok(report)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11712,6 +11712,13 @@ trim-repeated@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
+ts-invariant@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-invariant@^0.4.0:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3198,7 +3198,7 @@ bluebird@^3.1.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-body-parser@1.20.0, body-parser@^1.18.3, body-parser@^1.19.0:
+body-parser@1.20.0, body-parser@^1.18.3, body-parser@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
   integrity sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==


### PR DESCRIPTION
The `AsyncLocalStorage` API was introduced in node 14 to provide an async-friendly alternative to [thread-local storage](https://en.wikipedia.org/wiki/Thread-local_storage) in other programming environments.

In Express, this is particularly useful for capturing request-specific context in such a way that they can be shared across multiple asynchronous function calls without interfering with concurrent requests.

It looks like AsyncLocalStorage was promoted to stable as of node 16.4.0.

https://nodejs.org/api/async_context.html#asynchronous-context-tracking

---

Given the confidence that this API probably isn't going away, I decided it was worth trying out at least!

Happily, the API seems to do what it claims.  I didn't run into any issues working with tenant IDs, and the code required to get it working is all of about six lines!

Open questions:

1. Is `request` the right object to expose via AsyncLocalStorage?

I considered wrapping the express `request` in some kind of context object (e.g. `Context: { req, session, tenant_id }`).  I think it may make sense to do that at some stage, but I prefer starting with the simplest possible solution that works, until we know better.

2. Should we try to manage transactions using AsyncLocalStorage as well?

This one I'm very open to input on.  I think it's not quite clear we want to always assume a single global transaction, correct?