### PR TITLE
Release 2022-07-27

### DIFF
--- a/scripts/generateRules.mjs
+++ b/scripts/generateRules.mjs
@@ -10,6 +10,7 @@ import lodash from 'lodash'
 
 import { DATA_SHEET_TYPES, readVersionRecord } from '../src/server/services/records.js'
 import { SERVER_DATA_DIR, EMPTY_TEMPLATE_NAME, SRC_DIR } from '../src/server/environment.js'
+import { dropdownCorrections } from '../src/server/services/validation-rules.js'
 
 const { merge } = lodash
 const log = (msg) => { console.log(chalk.green(msg)) }
@@ -288,6 +289,28 @@ function validateExtractedDropdowns(extractedDropdowns) {
     throw new Error('Correct the dropdownNamesToFieldIds mappings to continue')
   }
 }
+
+function validateDropdownCorrections(extractedDropdowns) {
+  // Make sure that every correction configured refers to a real value in a dropdown somewhere
+  Object.keys(dropdownCorrections).forEach(valToCorrect => {
+    for (const dropdownName in extractedDropdowns) {
+      for (const dropdownValue of extractedDropdowns[dropdownName]) {
+        if (valToCorrect == dropdownValue) {
+          return
+        }
+      }
+    }
+    // Didn't find the value anywhere? Throw an error to force us to correct it
+    
+    // Getting this error?
+    // Did you recently add a new correction or update the worksheet?
+    // Check to make sure the key in dropdownCorrections exactly matches the key *currently* in
+    // the worksheet.
+    console.log(chalk.red(
+      `Error: correction for dropdown value ${valToCorrect} doesn't reference a real value.`))
+      throw new Error('Fix the dropdownCorrections configuration to continue.')
+  })
+}
 const run = async () => {
   log(`extracting rules from ${EMPTY_TEMPLATE_NAME}...`)
 
@@ -299,6 +322,7 @@ const run = async () => {
   const dropdowns = await extractDropdowns(workbook)
   validateExtractedDropdowns(dropdowns)
   await saveTo('templateDropdowns.json', dropdowns)
+  validateDropdownCorrections(dropdowns)
 
   const rules = await extractRules(workbook, logic, dropdowns)
   await saveTo('templateRules.json', rules)

--- a/src/server/services/generate-arpa-report.js
+++ b/src/server/services/generate-arpa-report.js
@@ -179,6 +179,7 @@ async function generateProject19 (records) {
             record.content.Name,
             record.content.Project_Identification_Number__c,
             record.content.Completion_Status__c,
+            record.content.Cancellation_Reason__c,
             currency(record.content.Adopted_Budget__c),
             currency(record.content.Total_Obligations__c),
             currency(record.content.Total_Expenditures__c),

--- a/src/server/services/validate-upload.js
+++ b/src/server/services/validate-upload.js
@@ -237,7 +237,7 @@ async function validateRecord ({ upload, record, typeRules: rules }) {
       // how do we format the value before checking it?
       let value = record[key]
       let formatFailures = 0
-      for (const formatter of rule.valueFormatters) {
+      for (const formatter of rule.validationFormatters) {
         try {
           value = formatter(value)
         } catch (e) {

--- a/src/server/services/validation-rules.js
+++ b/src/server/services/validation-rules.js
@@ -3,11 +3,38 @@ const srcRules = require('../lib/templateRules.json')
 
 const recordValueFormatters = {
   makeString: (val) => String(val),
-  trimWhitespace: (val) => val.trim(),
+  trimWhitespace: (val) => val ? val.trim() : val,
   removeCommas: (val) => val.replace(/,/g, ''),
   removeSepDashes: (val) => val.replace(/^-/, '').replace(/;\s*-/g, ';'),
-  toLowerCase: (val) => val.toLowerCase(),
-  childCareSpacing: (val) => (val === 'family or childcare' ? 'family or child care' : val)
+  toLowerCase: (val) => val.toLowerCase()
+}
+
+/*
+Structured data recording all the immediate corrections we want to apply to dropdowns.
+There are 2 types of corrections we can apply:
+1) The value in the currently committed input template is incorrect.
+2) A value in the dropdown list changed in the past, and we want to continue to allow legacy vals as valid inputs.
+In the first case, we will alter the validation rule to check against the new correct value, and
+then treat the value currently seen in the worksheet as an allowable legacy value.
+In both cases, we will foribly coerce any instances of legacy values into the correct value.
+This coercion happens whenever we read the value from the upload file, so it will apply to
+validations we perform, as well as values we export in reports.
+   */
+const dropdownCorrections = {
+  'Affordable housing supportive housing or recovery housing': {
+    correctedValue: 'Affordable housing, supportive housing, or recovery housing'
+  },
+  'COVID-19 testing sites and laboratories and acquisition of related equipment': {
+    correctedValue: 'COVID-19 testing sites and laboratories, and acquisition of related equipment'
+  },
+  'Family or child care': {
+    allowableLegacyValues: ['Family or childcare']
+  }
+  /*
+  'Mitigation measures in small businesses, nonprofits and impacted industries': {
+    correctedValue: 'TODO'  What is the correct value here?
+  }
+  */
 }
 
 function generateRules () {
@@ -25,24 +52,37 @@ function generateRules () {
   // for any values we format, we should format them the same way when we export
   for (const ruleType of Object.keys(rules)) {
     for (const rule of Object.values(rules[ruleType])) {
-      rule.valueFormatters = []
+      // validationFormatters are only applied when validating the records, so they
+      // aren't used during exports.
+      // persistentFormatters are always applied as soon as a value is read from a
+      // an upload, so they will affect both validation AND the exported value.
+      rule.validationFormatters = []
+      rule.persistentFormatters = []
 
       if (rule.dataType === 'String') {
-        rule.valueFormatters.push(recordValueFormatters.makeString)
-        rule.valueFormatters.push(recordValueFormatters.trimWhitespace)
+        rule.validationFormatters.push(recordValueFormatters.makeString)
+        rule.persistentFormatters.push(recordValueFormatters.trimWhitespace)
       }
 
       if (rule.dataType === 'Multi-Select') {
-        rule.valueFormatters.push(recordValueFormatters.removeCommas)
-        rule.valueFormatters.push(recordValueFormatters.removeSepDashes)
+        rule.validationFormatters.push(recordValueFormatters.removeCommas)
+        rule.validationFormatters.push(recordValueFormatters.removeSepDashes)
       }
 
       if (rule.listVals.length > 0) {
-        rule.valueFormatters.push(recordValueFormatters.toLowerCase)
-      }
+        rule.validationFormatters.push(recordValueFormatters.toLowerCase)
 
-      if (rule.listVals.includes('Family or child care')) {
-        rule.valueFormatters.push(recordValueFormatters.childCareSpacing)
+        for (let i = 0; i < rule.listVals.length; i++) {
+          const worksheetValue = rule.listVals[i]
+          const correction = dropdownCorrections[worksheetValue]
+          if (correction) {
+            const correctValue = correction.correctedValue || worksheetValue
+            const valuesToCoerce = (correction.allowableLegacyValues || []).concat(worksheetValue)
+
+            rule.listVals[i] = correctValue
+            rule.persistentFormatters.push(val => valuesToCoerce.includes(val) ? correctValue : val)
+          }
+        }
       }
     }
   }
@@ -59,5 +99,6 @@ function getRules () {
 }
 
 module.exports = {
-  getRules
+  getRules,
+  dropdownCorrections
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4078,9 +4078,9 @@ core-js@^2.6.12:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.21.1, core-js@^3.8.3:
-  version "3.23.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.23.5.tgz#1f82b0de5eece800827a2f59d597509c67650475"
-  integrity sha512-7Vh11tujtAZy82da4duVreQysIoO2EvVrur7y6IzZkH1IHPSekuDi8Vuw1+YKjkbfWLRD7Nc9ICQ/sIUDutcyg==
+  version "3.24.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.24.0.tgz#4928d4e99c593a234eb1a1f9abd3122b04d3ac57"
+  integrity sha512-IeOyT8A6iK37Ep4kZDD423mpi6JfPRoPUdQwEWYiGolvn4o6j2diaRzNfDfpTdu3a5qMbrGUzKUpYpRY8jXCkQ==
 
 core-util-is@1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4339,9 +4339,9 @@ datauri@^4.1.0:
     mimer "^2.0.2"
 
 date-fns@^2.16.1, date-fns@^2.17.0, date-fns@^2.23.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
-  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.1.tgz#9667c2615525e552b5135a3116b95b1961456e60"
+  integrity sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==
 
 de-indent@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This release included fixes for:
- Incorrect dropdown values: 
  If the uploaded worksheet included any of the following incorrect values
	- Affordable housing supportive housing or recovery housing
	- COVID-19 testing sites and laboratories and acquisition of related equipment
	- Family or childcare

  Then the validation will still pass, and the export csvs will include these corrected values instead:
	- Affordable housing, supportive housing, or recovery housing
	- COVID-19 testing sites and laboratories, and acquisition of related equipment
	- Family or child care

  Unfortunately we still don't know what the correct value for "Mitigation measures in small businesses, nonprofits and impacted industries" is supposed to be, so we haven't fixed that. 

- Fixed a bug that caused exports for EC codes 1.9 and 2.34 to miss a field, so most of the csv was off by a column

- Free text inputs now have leading and trailing whitespace removed before being validated or written to the export csvs.