### PR TITLE
GOST integration: Adjust database accesses for shared tables

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -109,7 +109,7 @@ export default {
       return this.$store.getters.agencyName(this.user.agency_id)
     },
     role: function () {
-      return this.$store.getters.user.role
+      return this.$store.getters.user.role.name
     },
     loggedIn: function () {
       return this.$store.state.user !== null

--- a/src/server/access-helpers.js
+++ b/src/server/access-helpers.js
@@ -7,7 +7,7 @@ function requireUser (req, res, next) {
     userAndRole(req.signedCookies.userId).then(user => {
       req.session = { ...req.session, user }
       next()
-    })
+    }).catch(e => next(e))
   }
 }
 
@@ -22,7 +22,7 @@ function requireAdminUser (req, res, next) {
         req.session = { ...req.session, user }
         next()
       }
-    })
+    }).catch(e => next(e))
   }
 }
 

--- a/src/server/access-helpers.js
+++ b/src/server/access-helpers.js
@@ -16,7 +16,7 @@ function requireAdminUser (req, res, next) {
     res.sendStatus(403)
   } else {
     userAndRole(req.signedCookies.userId).then(user => {
-      if (user.role !== 'admin') {
+      if (user.role.name !== 'admin') {
         res.sendStatus(403)
       } else {
         req.session = { ...req.session, user }

--- a/src/server/db/users.js
+++ b/src/server/db/users.js
@@ -6,41 +6,37 @@ const { useTenantId } = require('../use-request')
 
 // Takes the result of a users query joined on roles and formats the role object as a member, matching
 // the format present in GOST.
-function formatUserRole(row) {
+function formatUserRole (row) {
   const role = {
     id: row.role_id,
     name: row.role_name,
-    rules: row.role_rules,
-  };
+    rules: row.role_rules
+  }
 
-  delete row.role;
-  delete row.role_id;
-  delete row.role_name;
-  delete row.role_rules;
-  row.role = role;
+  delete row.role
+  delete row.role_id
+  delete row.role_name
+  delete row.role_rules
+  row.role = role
 
-  return row;
+  return row
 }
 
 async function users (trns = knex) {
   const tenantId = useTenantId()
 
   const rows = await trns('users')
-    .leftJoin('agencies', 'users.agency_id', 'agencies.id')
     .join('roles', 'roles.name', 'users.role')
     .select(
       'users.*',
-      // TODO(mbroussard): deal with these agency join cols
-      'agencies.name AS agency_name',
-      'agencies.code AS agency_code',
       'roles.name as role_name',
       'roles.rules as role_rules',
-      'roles.id as role_id',
+      'roles.id as role_id'
     )
     .where('users.tenant_id', tenantId)
-    .orderBy('email');
+    .orderBy('email')
 
-  return rows.map(formatUserRole);
+  return rows.map(formatUserRole)
 }
 
 function createUser (user, trns = knex) {
@@ -67,7 +63,7 @@ function updateUser (user, trns = knex) {
 }
 
 function user (id, trns = knex) {
-  return userAndRole(id, trns);
+  return userAndRole(id, trns)
 }
 
 async function userAndRole (id, trns = knex) {
@@ -80,9 +76,9 @@ async function userAndRole (id, trns = knex) {
       'roles.id as role_id'
     )
     .where('users.id', id)
-    .then(r => r[0]);
+    .then(r => r[0])
 
-  return formatUserRole(row);
+  return formatUserRole(row)
 }
 
 // NOTE(mbroussard): roles are currently global and shared across all tenants.

--- a/src/server/routes/sessions.js
+++ b/src/server/routes/sessions.js
@@ -15,7 +15,7 @@ function isExpired (expires) {
   return now > expires
 }
 
-router.get('/', function (req, res) {
+router.get('/', function (req, res, next) {
   const { passcode } = req.query
   if (passcode) {
     accessToken(passcode).then(token => {
@@ -35,7 +35,7 @@ router.get('/', function (req, res) {
       }
     })
   } else if (req.signedCookies.userId) {
-    userAndRole(req.signedCookies.userId).then(user => res.json({ user }))
+    userAndRole(req.signedCookies.userId).then(user => res.json({ user })).catch(e => next(e))
   } else {
     res.json({ message: 'No session' })
   }

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -20,13 +20,13 @@ async function validateUser (user, creator) {
     throw new Error('Role required')
   }
 
-  if (agency_id) {
-    const agency = await agencyById(agency_id)
-    if (!agency || agency.tenant_id !== creator.tenant_id) {
-      throw new Error('Invalid agency')
-    }
-  } else if (role !== 'admin') {
-    throw new Error('Reporter role requires agency')
+  if (!agency_id) {
+    throw new Error('Cannot create user without agency_id');
+  }
+
+  const agency = await agencyById(agency_id)
+  if (!agency || agency.tenant_id !== creator.tenant_id) {
+    throw new Error('Invalid agency')
   }
 
   return null
@@ -34,7 +34,7 @@ async function validateUser (user, creator) {
 
 router.get('/', requireUser, async function (req, res, next) {
   const allUsers = await listUsers()
-  const curUser = allUsers.find(u => u.id === Number(req.signedCookies.userId))
+  const curUser = allUsers.find(u => u.id === Number(req.session.user.id))
 
   const users = (curUser.role === 'admin') ? allUsers : [curUser]
   const roles = await listRoles()

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -36,7 +36,7 @@ router.get('/', requireUser, async function (req, res, next) {
   const allUsers = await listUsers()
   const curUser = allUsers.find(u => u.id === Number(req.session.user.id))
 
-  const users = (curUser.role === 'admin') ? allUsers : [curUser]
+  const users = (curUser.role.name === 'admin') ? allUsers : [curUser]
   const roles = await listRoles()
   res.json({ users, roles })
 })

--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -21,7 +21,7 @@ async function validateUser (user, creator) {
   }
 
   if (!agency_id) {
-    throw new Error('Cannot create user without agency_id');
+    throw new Error('Cannot create user without agency_id')
   }
 
   const agency = await agencyById(agency_id)

--- a/src/views/Agency.vue
+++ b/src/views/Agency.vue
@@ -7,15 +7,6 @@
     </div>
 
     <div v-else>
-      <div class="form-group row" v-if="!isNew">
-        <div class="col-sm-2">
-          Created:
-        </div>
-        <div class="col-sm-10">
-          {{ agency.created_at }} by {{ agency.created_by }}
-        </div>
-      </div>
-
       <StandardForm :initialRecord="agency" :cols="cols" @save="onSave" @reset="onReset" :key="formKey" />
     </div>
   </div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -53,7 +53,7 @@ export default {
       return this.role === 'admin'
     },
     role: function () {
-      return this.$store.getters.user.role
+      return this.$store.getters.user.role.name
     },
     viewingOpenPeriod () {
       return this.$store.getters.viewPeriodIsCurrent

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -70,13 +70,19 @@ export default {
 
       this.user = null
       await this.$store.dispatch('updateUsersRoles')
-      this.user = this.$store.state.users.find(u => u.id === Number(this.userId))
+
+      const storeUser = this.$store.state.users.find(u => u.id === Number(this.userId))
+      // StandardForm deals in ARPA Reporter's former user object representation where "role" is a simple string field, but the API and store now deal in the GOST format where role is an object.
+      this.user = {...storeUser, role: storeUser.role.name};
     },
     onSave: async function (user) {
       this.user = null
 
       try {
-        const result = await post('/api/users', { user })
+        // StandardForm deals in ARPA Reporter's former user object representation where "role" is a simple string field, but the API now deals in the GOST format where role is an object.
+        const gostUser = {...user, role: this.roles.find(r => r.name == user.role)};
+
+        const result = await post('/api/users', { user: gostUser })
         if (result.error) throw new Error(result.error)
 
         const text = this.isNew

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -73,14 +73,14 @@ export default {
 
       const storeUser = this.$store.state.users.find(u => u.id === Number(this.userId))
       // StandardForm deals in ARPA Reporter's former user object representation where "role" is a simple string field, but the API and store now deal in the GOST format where role is an object.
-      this.user = {...storeUser, role: storeUser.role.name};
+      this.user = { ...storeUser, role: storeUser.role.name }
     },
     onSave: async function (user) {
       this.user = null
 
       try {
         // StandardForm deals in ARPA Reporter's former user object representation where "role" is a simple string field, but the API now deals in the GOST format where role is an object.
-        const gostUser = {...user, role: this.roles.find(r => r.name == user.role)};
+        const gostUser = { ...user, role: this.roles.find(r => r.name === user.role) }
 
         const result = await post('/api/users', { user: gostUser })
         if (result.error) throw new Error(result.error)

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -9,7 +9,7 @@
 
     <vue-good-table
       :columns="columns"
-      :rows="users"
+      :rows="usersWithAgency"
       :search-options="{
         enabled: true,
         placeholder: 'Filter users...'
@@ -17,7 +17,7 @@
       styleClass="vgt-table table table-striped table-bordered"
       >
       <div slot="emptystate">
-        No Recipients
+        No Users
       </div>
 
       <template slot="table-row" slot-scope="props">
@@ -27,6 +27,10 @@
 
         <span v-else-if="props.column.field === 'agency_id' && props.row.agency_id">
           {{ props.row.agency_name }} ({{ props.row.agency_code }})
+        </span>
+
+        <span v-else-if="props.column.field === 'role'">
+          {{ props.row.role.name }}
         </span>
 
         <span v-else>
@@ -83,6 +87,15 @@ export default {
           field: 'edit'
         }
       ]
+    },
+    // This is just a shim to populate the agency_name/agency_code fields which ARPA Reporter previously
+    // included on user objects, but GOST does not.
+    usersWithAgency: function () {
+      return this.users.map(user => {
+        const agencyId = user.agency_id
+        const agency = this.$store.state.agencies.find(a => a.id === agencyId) || { name: 'Loading...', code: '???' }
+        return { ...user, agency_name: agency.name, agency_code: agency.code }
+      })
     }
   },
   methods: {


### PR DESCRIPTION
For the tables that will be shared with GOST, this makes several changes in advance on the ARPA side to make its usage similar to in GOST and only depending on fields that are present in GOST's accessors. Notably:
- `users`:
  - instead of having `role` be a string field on user objects, it is not an object with the `roles` row's fields (one place we do not do this is in the add/edit user flow because StandardForm would have to be changed significantly; instead we just convert back and forth between the two formats on the client)
  - don't include `agency_name` and `agency_code` fields on user objects; instead load that information separately from the VueX store in the one clientside place that cared about them
  - require an `agency_id` when creating or updating a user, since it is intended to be nonnullable in GOST (technically isn't right now, but should be; see https://github.com/usdigitalresponse/usdr-gost/issues/298). This was already true for non-admin users in ARPA, this is only a change for admin users which could be agency-less in ARPA before.
- `agencies`:
  - no longer using/displaying the `created_by`/`created_at` fields (`updated_at`/`updated_by` were already unused)
- `roles`: no changes necessary; the shape and usage of this table is already the same in both repos
- `access_tokens`: no changes necessary since no ARPA code will directly touch these tables after the migration; instead `routes/sessions` and `access-helpers` modules already existing in GOST will be used.
- miscellaneous
  - don't access `signedCookies` directly outside of `requireUser` etc.

These changes are in preparation for merging the two repos, when ARPA's accessor files will be replaced by the shims implemented in sister PR https://github.com/usdigitalresponse/usdr-gost/pull/299.

Overall design doc for integration project: https://www.notion.so/usdr/GOST-ARPA-integration-technical-plan-cffc5800c0414660816a0920b959da82