### PR TITLE
GOST integration: misc preparations for copy

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -143,7 +143,7 @@ export default {
         .then(() => this.$router.push({ path: '/login' }))
     },
     navLinkClass (to) {
-      if (document.location.pathname === to) {
+      if (this.$route.path === to) {
         return 'nav-link active'
       }
       return 'nav-link'

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -111,7 +111,9 @@ const routes = [
 
 const router = new VueRouter({
   mode: 'history',
-  base: process.env.BASE_URL,
+  base: process.env.VUE_APP_IS_GOST
+    ? `${process.env.BASE_URL}arpa_reporter/`
+    : process.env.BASE_URL,
   routes
 })
 

--- a/src/server/configure.js
+++ b/src/server/configure.js
@@ -10,13 +10,7 @@ const environment = require('./environment')
 const publicPath = resolve(__dirname, '../../dist')
 const staticConf = { maxAge: '1y', etag: false }
 
-module.exports = (app, options = {}) => {
-  if (!options.disableRequestLogging) {
-    app.use(morgan('common'))
-  }
-  app.use(bodyParser.json())
-  app.use(cookieParser(environment.COOKIE_SECRET))
-
+function configureApiRoutes (app) {
   app.use('/api/agencies', require('./routes/agencies'))
   app.use(
     '/api/application_settings',
@@ -30,6 +24,16 @@ module.exports = (app, options = {}) => {
   app.use('/api/uploads', require('./routes/uploads'))
   app.use('/api/users', require('./routes/users'))
   app.use('/api/health', require('./routes/health'))
+}
+
+function configureApp (app, options = {}) {
+  if (!options.disableRequestLogging) {
+    app.use(morgan('common'))
+  }
+  app.use(bodyParser.json())
+  app.use(cookieParser(environment.COOKIE_SECRET))
+
+  configureApiRoutes(app)
 
   if (!environment.IS_DEV) {
     const staticMiddleware = express.static(publicPath, staticConf)
@@ -43,3 +47,5 @@ module.exports = (app, options = {}) => {
     app.use(staticMiddleware)
   }
 }
+
+module.exports = { configureApp, configureApiRoutes }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -5,7 +5,7 @@ const express = require('express')
 require('express-async-errors')
 
 const { requestProviderMiddleware } = require('./use-request')
-const configureAPI = require('./configure')
+const { configureApp } = require('./configure')
 const environment = require('./environment')
 
 console.log(`Database is ${environment.POSTGRES_URL}`)
@@ -14,7 +14,7 @@ const app = express()
 
 app.use(requestProviderMiddleware)
 
-configureAPI(app)
+configureApp(app)
 
 app.listen(
   environment.PORT,

--- a/src/views/ReportingPeriods.vue
+++ b/src/views/ReportingPeriods.vue
@@ -27,7 +27,7 @@
           <td>{{ formatDate(p.end_date) }}</td>
           <td>{{ p.template_filename }}</td>
           <td>
-            <a v-if="!p.certified_at" :href="`/new_template/${p.id}`">Upload Template</a>
+            <router-link v-if="!p.certified_at" :to="`/new_template/${p.id}`">Upload Template</router-link>
           </td>
           <td>
             <span v-if="isCurrentReportingPeriod(p)">
@@ -43,7 +43,7 @@
             </span>
           </td>
           <td>
-            <a v-if="!p.certified_at" :href="`/reporting_periods/${p.id}`" class="btn btn-sm btn-secondary">Edit</a>
+            <router-link v-if="!p.certified_at" :to="`/reporting_periods/${p.id}`" class="btn btn-sm btn-secondary">Edit</router-link>
           </td>
         </tr>
       </tbody>

--- a/tests/server/fixtures/add-dummy-data.js
+++ b/tests/server/fixtures/add-dummy-data.js
@@ -17,7 +17,7 @@ module.exports = {
 if (require.main === module) {
   require('dotenv').config()
   const knex = require('../../../src/server/db/connection')
-  return setupAgencies(knex).then(() => {
+  setupAgencies(knex).then(() => {
     knex.destroy()
   })
 }

--- a/tests/server/routes/route_test_helpers.js
+++ b/tests/server/routes/route_test_helpers.js
@@ -5,7 +5,7 @@ const express = require('express')
 const supertest = require('supertest')
 const { sign: signCookie } = require('cookie-signature')
 
-const configureAPI = requireSrc(path.resolve(__dirname, '../configure'))
+const { configureApp } = requireSrc(path.resolve(__dirname, '../configure'))
 const { requestProviderMiddleware } = require('../../../src/server/use-request')
 const { knex } = require('../mocha_init')
 
@@ -32,7 +32,7 @@ async function getSessionCookie (userIdOrEmail) {
 function makeTestServer () {
   const app = express()
   app.use(requestProviderMiddleware)
-  configureAPI(app, {
+  configureApp(app, {
     // The normal request logging from Morgan just clutters Mocha's test runner output
     disableRequestLogging: true
   })

--- a/tests/unit/components/Navigation.spec.js
+++ b/tests/unit/components/Navigation.spec.js
@@ -8,6 +8,7 @@ localVue.use(Vuex)
 
 describe('Navigation.vue', () => {
   let store
+  let $route
   beforeEach(() => {
     store = new Vuex.Store({
       getters: {
@@ -18,13 +19,15 @@ describe('Navigation.vue', () => {
         agencyName: () => id => `Agency ${id}`
       }
     })
+    $route = { path: '/' }
   })
 
   it('renders the nav element', () => {
     const wrapper = shallowMount(Navigation, {
       store,
       localVue,
-      stubs: ['router-link', 'router-view']
+      stubs: ['router-link', 'router-view'],
+      mocks: { $route }
     })
     const navbars = wrapper.findAll('nav.navbar')
     expect(navbars.length).to.equal(1) // has one navbar element
@@ -37,7 +40,8 @@ describe('Navigation.vue', () => {
     const wrapper = shallowMount(Navigation, {
       store,
       localVue,
-      stubs: ['router-link', 'router-view']
+      stubs: ['router-link', 'router-view'],
+      mocks: { $route }
     })
     const r = wrapper.find('a.navbar-brand')
     expect(r.text()).to.include('ARPA Reporter')


### PR DESCRIPTION
- Remove some bad syntax that Babel (in my [import rewriter](https://github.com/usdigitalresponse/usdr-gost/pull/297) script) choked on
- add an environment variable check to gate VueRouter `base` on whether running in standalone ARPA reporter repo or GOST
- fix dependencies on being mounted at root path
  - remove raw reference to document.location in Navigation.vue; use VueRouter's `$route` object instead which accounts for varying `base`
  - replace some `a` tags with `router-link` tags
- organize `configure.js` into separate functions that can be more easily called from GOST's after repo merge