### PR TITLE
Followup fix from #505: handle role properly when creating new users

### DIFF
--- a/src/server/db/users.js
+++ b/src/server/db/users.js
@@ -43,7 +43,11 @@ function createUser (user, trns = knex) {
   const tenantId = useTenantId()
 
   return trns('users')
-    .insert({ ...user, tenant_id: tenantId })
+    .insert({
+      ...user,
+      role: user.role.name,
+      tenant_id: tenantId
+    })
     .returning('*')
     .then(rows => rows[0])
 }


### PR DESCRIPTION
This fixes one callsite missed in #505's rework of how user objects are dealt with: when creating a new user in legacy ARPA Reporter environment, need to convert `user.role` object back into string (in GOST, this code is replaced).