### PR TITLE
GOST integration: ARPA-side changes to allow running ARPA tests in GOST repo

### DIFF
--- a/scripts/generateRules.mjs
+++ b/scripts/generateRules.mjs
@@ -9,7 +9,7 @@ import XLSX from 'xlsx'
 import lodash from 'lodash'
 
 import { DATA_SHEET_TYPES, readVersionRecord } from '../src/server/services/records.js'
-import { SERVER_DATA_DIR, EMPTY_TEMPLATE_NAME, SRC_DIR } from '../src/server/environment.js'
+import { SERVER_DATA_DIR, EMPTY_TEMPLATE_NAME, SERVER_CODE_DIR } from '../src/server/environment.js'
 import { dropdownCorrections } from '../src/server/services/validation-rules.js'
 
 const { merge } = lodash
@@ -268,7 +268,7 @@ async function extractLogic (workbook) {
 }
 
 async function saveTo (destFilename, data) {
-  const destPath = path.join(SRC_DIR, 'server', 'lib', destFilename)
+  const destPath = path.join(SERVER_CODE_DIR, 'lib', destFilename)
   const strData = JSON.stringify(data, null, 2)
 
   log(`writing to ${destFilename}`)

--- a/src/server/environment.js
+++ b/src/server/environment.js
@@ -14,8 +14,10 @@ const DATA_DIR = resolve(process.env.DATA_DIR)
 const UPLOAD_DIR = join(DATA_DIR, 'uploads')
 const PERIOD_TEMPLATES_DIR = join(UPLOAD_DIR, 'period_templates')
 
-const SRC_DIR = resolve(join(__dirname, '..'))
-const SERVER_DATA_DIR = join(SRC_DIR, 'server', 'data')
+// Note: in legacy standalone ARPA Report repo, this points to src/server; in GOST
+// it points to packages/server/src/arpa_reporter
+const SERVER_CODE_DIR = __dirname
+const SERVER_DATA_DIR = join(SERVER_CODE_DIR, 'data')
 
 const EMPTY_TEMPLATE_NAME = 'ARPA SFRF Reporting Workbook v20220705.xlsm'
 
@@ -42,7 +44,7 @@ module.exports = {
   DATA_DIR,
   UPLOAD_DIR,
   PERIOD_TEMPLATES_DIR,
-  SRC_DIR,
+  SERVER_CODE_DIR,
   SERVER_DATA_DIR,
   EMPTY_TEMPLATE_NAME,
   POSTGRES_URL,

--- a/tests/server/environment.spec.js
+++ b/tests/server/environment.spec.js
@@ -1,14 +1,40 @@
 const assert = require('assert')
+const path = require('path')
+const fs = require('fs/promises')
 
-const underTest = '../../src/server/environment'
+const env = require('../../src/server/environment')
 
 describe('environment settings', function () {
-  beforeEach('clear env module', function () {
-    delete require.cache[require.resolve(underTest)]
+  it('SERVER_CODE_DIR point to the right place', async function () {
+    const testPaths = [
+      'environment.js',
+      'lib/ensure-async-context.js'
+    ]
+
+    for (const relative of testPaths) {
+      const absolute = path.join(env.SERVER_CODE_DIR, relative)
+      const pathExists = await exists(absolute)
+      assert.ok(pathExists, `expected ${absolute} to exist, is SERVER_CODE_DIR wrong?`)
+    }
   })
 
-  it('points the CODE_DIR at src', function () {
-    const env = require(underTest)
-    assert.equal(env.SRC_DIR.slice(env.SRC_DIR.length - 3), 'src')
+  it('SERVER_DATA_DIR point to the right place', async function () {
+    const testPaths = [
+      'treasury',
+      env.EMPTY_TEMPLATE_NAME
+    ]
+
+    for (const relative of testPaths) {
+      const absolute = path.join(env.SERVER_DATA_DIR, relative)
+      const pathExists = await exists(absolute)
+      assert.ok(pathExists, `expected ${absolute} to exist, is SERVER_DATA_DIR wrong?`)
+    }
   })
 })
+
+function exists (fpath) {
+  return fs.access(fpath).then(
+    () => true,
+    () => false
+  )
+}

--- a/tests/server/fixtures/add-dummy-data.js
+++ b/tests/server/fixtures/add-dummy-data.js
@@ -1,10 +1,8 @@
+
+const { isRunningInGOST } = require('../helpers/is_gost')
+
 const setupAgencies = async knex => {
-  // We check if a "tenants" table exists to tell if we're running under GOST or in the legacy arpa-reporter
-  // repo.
-  const tenantsTable = await knex('pg_tables')
-    .where({ schemaname: 'public', tablename: 'tenants' })
-    .select('tablename')
-  const isGost = tenantsTable.length !== 0
+  const isGost = await isRunningInGOST(knex)
 
   return knex('agencies').insert([
     { id: 1, name: 'Generic Government', code: 'GOV', tenant_id: 0 },

--- a/tests/server/fixtures/add-dummy-data.js
+++ b/tests/server/fixtures/add-dummy-data.js
@@ -1,10 +1,20 @@
-const setupAgencies = knex => {
+const setupAgencies = async knex => {
+  // We check if a "tenants" table exists to tell if we're running under GOST or in the legacy arpa-reporter
+  // repo.
+  const tenantsTable = await knex('pg_tables')
+    .where({ schemaname: 'public', tablename: 'tenants' })
+    .select('tablename')
+  const isGost = tenantsTable.length !== 0
+
   return knex('agencies').insert([
-    { name: 'Generic Government', code: 'GOV', tenant_id: 0 },
-    { name: 'Office of Management and Budget', code: 'OMB', tenant_id: 0 },
-    { name: 'Department of Health', code: 'DOH', tenant_id: 0 },
-    { name: 'Executive Office of Health and Human Services', code: 'EOHHS', tenant_id: 0 }
-  ]).then(() => {
+    { id: 1, name: 'Generic Government', code: 'GOV', tenant_id: 0 },
+    { id: 2, name: 'Office of Management and Budget', code: 'OMB', tenant_id: 0 },
+    { id: 3, name: 'Department of Health', code: 'DOH', tenant_id: 0 },
+    { id: 4, name: 'Executive Office of Health and Human Services', code: 'EOHHS', tenant_id: 0 }
+  ].map(
+    // GOST has a non-null main_agency_id field on agencies that legacy arpa-reporter does not have
+    row => isGost ? ({ ...row, main_agency_id: row.id }) : row
+  )).then(() => {
     return 'Agency data added OK'
   })
 }

--- a/tests/server/helpers/is_gost.js
+++ b/tests/server/helpers/is_gost.js
@@ -1,0 +1,11 @@
+
+async function isRunningInGOST (knex) {
+  // We check if a "tenants" table exists to tell if we're running under GOST or in the legacy arpa-reporter
+  // repo.
+  const tenantsTable = await knex('pg_tables')
+    .where({ schemaname: 'public', tablename: 'tenants' })
+    .select('tablename')
+  return tenantsTable.length !== 0
+}
+
+module.exports = { isRunningInGOST }

--- a/tests/server/mocha_init.js
+++ b/tests/server/mocha_init.js
@@ -8,8 +8,16 @@ const { setupAgencies } = require('./fixtures/add-dummy-data')
 // `or
 // `requireSrc(`${__dirname}/a/path`) does a require of `a/path` relative
 // to the corresponding `src` dir of the tests `__dirname`,
-global.requireSrc = f =>
-  require(f.replace(/\/tests\//, '/src/').replace(/(\.[^.]*)*\.spec/, ''))
+global.requireSrc = function requireSrc (fpath) {
+  return require(
+    fpath
+      .replace(/(\.[^.]*)*\.spec/, '')
+      // GOST repo path of ARPA Reporter code
+      .replace(/\/__tests__\/arpa_reporter\/server\//, '/src/arpa_reporter/')
+      // Legacy ARPA repo paths
+      .replace(/\/tests\//, '/src/')
+  )
+}
 
 module.exports = {
   knex,

--- a/tests/server/mocha_wrapper.sh
+++ b/tests/server/mocha_wrapper.sh
@@ -5,9 +5,18 @@ set -o errexit
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Import .env variables if not already defined.
-DOTENV="$DIR/../../.env"
+if [[ $DIR =~ "__tests__/arpa_reporter" ]]
+then
+  # in GOST, mocha_wrapper.sh will be located in packages/server/__tests__/arpa_reporter/server
+  # and .env inside packages/server
+  DOTENV="$DIR/../../../.env"
+else
+  # in legacy ARPA Reporter repo, mocha_wrapper.sh is located in tests/server and .env at repo root
+  DOTENV="$DIR/../../.env"
+fi
+
 source /dev/stdin <<DONE
-$(grep -v '^#' $DOTENV | sed -E 's|^(.+)=(.*)|: ${\1=\2}; export \1|g')
+$(grep -v '^#' $DOTENV | sed -E 's|^([^=]+)=(.*)|: ${\1=\2}; export \1|g')
 DONE
 
 # note: this is the DB name of the non-test db, used in reset-db.sh to check if
@@ -30,6 +39,6 @@ $DIR/reset-db.sh
 if [ $# -gt 0 ]; then
   mocha --require=`dirname $0`/mocha_init.js $*
 else
-  mocha --require=`dirname $0`/mocha_init.js 'tests/server/**/*.spec.js'
+  mocha --require=`dirname $0`/mocha_init.js "$DIR"'/**/*.spec.js'
 fi
 

--- a/tests/server/reset-db.sh
+++ b/tests/server/reset-db.sh
@@ -4,6 +4,8 @@ set -o pipefail
 set -o errexit
 set -o nounset
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 dbconn=${POSTGRES_URL#*//}  # from postgres://user:pass@host/dbname -> user:pass@host/dbname
 userpass=${dbconn%@*}       # 'user:pass'
 hostdbname=${dbconn#*@}         # host/dbname
@@ -43,4 +45,4 @@ else
 fi
 
 yarn knex migrate:latest
-yarn knex --knexfile tests/server/knexfile.js seed:run
+yarn knex --knexfile $DIR/knexfile.js seed:run

--- a/tests/server/seeds/00_gost_tenants.js
+++ b/tests/server/seeds/00_gost_tenants.js
@@ -1,0 +1,25 @@
+
+// This seed exists for compatibility between both the legacy arpa-reporter repo and ARPA Reporter tests
+// running within GOST. In GOST, there is a separate tenants table with FKs to it, so the latter seeds
+// fail if there is not already a row in the tenants table.
+exports.seed = async function (knex) {
+  const rows = await knex('pg_tables')
+    .where({ schemaname: 'public', tablename: 'tenants' })
+    .select('tablename')
+  if (rows.length === 0) {
+    return
+  } else {
+    console.error('!!!!', rows)
+  }
+
+  await knex('tenants').insert([
+    {
+      id: 0,
+      display_name: 'Tenant 0 for ARPA Reporter unit tests'
+    },
+    {
+      id: 1,
+      display_name: 'Tenant 1 for ARPA Reporter unit tests'
+    }
+  ])
+}

--- a/tests/server/seeds/00_gost_tenants.js
+++ b/tests/server/seeds/00_gost_tenants.js
@@ -1,15 +1,13 @@
 
+const { isRunningInGOST } = require('../helpers/is_gost')
+
 // This seed exists for compatibility between both the legacy arpa-reporter repo and ARPA Reporter tests
 // running within GOST. In GOST, there is a separate tenants table with FKs to it, so the latter seeds
 // fail if there is not already a row in the tenants table.
 exports.seed = async function (knex) {
-  const rows = await knex('pg_tables')
-    .where({ schemaname: 'public', tablename: 'tenants' })
-    .select('tablename')
-  if (rows.length === 0) {
+  const isGost = await isRunningInGOST(knex)
+  if (!isGost) {
     return
-  } else {
-    console.error('!!!!', rows)
   }
 
   await knex('tenants').insert([

--- a/tests/server/seeds/01_roles.js
+++ b/tests/server/seeds/01_roles.js
@@ -1,4 +1,8 @@
-exports.seed = function (knex) {
+const { isRunningInGOST } = require('../helpers/is_gost')
+
+exports.seed = async function (knex) {
+  const isGost = await isRunningInGOST(knex)
+
   // Deletes ALL existing entries
   return knex('roles')
     .del()
@@ -6,7 +10,7 @@ exports.seed = function (knex) {
       // Inserts seed entries
       return knex('roles').insert([
         { name: 'admin', rules: {} },
-        { name: 'reporter', rules: {} }
+        { name: isGost ? 'staff' : 'reporter', rules: {} }
       ])
     })
 }

--- a/tests/server/seeds/02_users.js
+++ b/tests/server/seeds/02_users.js
@@ -1,5 +1,8 @@
 require('dotenv').config()
 
+const { isRunningInGOST } = require('../helpers/is_gost')
+const _ = require('lodash')
+
 const adminList = (process.env.INITIAL_ADMIN_EMAILS || '').split(/\s*,\s*/)
 const agencyUserList = (process.env.INITIAL_AGENCY_EMAILS || '').split(
   /\s*,\s*/
@@ -20,29 +23,38 @@ const unitTestUsers = [
   }
 ]
 
+// To allow this seed to run in both legacy ARPA Reporter repo and GOST, we must account for slightly
+// different format and names of role field on users
+function reformatUserRoleForGost (user, roles) {
+  const adminRole = roles.find(role => role.name === 'admin')
+  const staffRole = roles.find(role => role.name === 'staff')
+  if (!adminRole || !staffRole) {
+    throw new Error('expected admin and staff role to exist in GOST')
+  }
+
+  return {
+    ..._.omit(user, 'role'),
+    role_id: user.role === 'admin' ? adminRole.id : staffRole.id
+  }
+}
+
 exports.seed = async function (knex) {
-  // Deletes ALL existing admins and reporters
+  const isGost = await isRunningInGOST(knex)
+
+  // Deletes ALL existing users
   // TODO(mbroussard): moot since mocha_wrapper.sh deletes and recreates the DB?
   await knex('users')
-    .where({ role: 'admin' })
-    .del()
-  await knex('users')
-    .where({ role: 'reporter' })
     .del()
 
-  // Fixed test users specified in this file
-  await knex('users').insert(unitTestUsers)
+  const roles = await knex('roles').select('*')
+  const users = [
+    // Fixed test users specified in this file
+    ...unitTestUsers,
+    // Test users specified by environment variable
+    // TODO(mbroussard): why does this exist if this seed is only used for tests?
+    ...adminList.map(email => ({ email, name: email, role: 'admin', tenant_id: 0 })),
+    ...agencyUserList.map(email => ({ email, name: email, role: 'reporter', tenant_id: 0 }))
+  ].map(user => isGost ? reformatUserRoleForGost(user, roles) : user)
 
-  // Test users specified by environment variable
-  // TODO(mbroussard): why does this exist if this seed is only used for tests?
-  await knex('users').insert(
-    adminList.map(email => {
-      return { email, name: email, role: 'admin', tenant_id: 0 }
-    })
-  )
-  await knex('users').insert(
-    agencyUserList.map(email => {
-      return { email, name: email, role: 'reporter', tenant_id: 0 }
-    })
-  )
+  await knex('users').insert(users)
 }

--- a/tests/server/seeds/02_users.js
+++ b/tests/server/seeds/02_users.js
@@ -3,10 +3,10 @@ require('dotenv').config()
 const { isRunningInGOST } = require('../helpers/is_gost')
 const _ = require('lodash')
 
-const adminList = (process.env.INITIAL_ADMIN_EMAILS || '').split(/\s*,\s*/)
+const adminList = (process.env.INITIAL_ADMIN_EMAILS || '').split(/\s*,\s*/).filter(_.identity)
 const agencyUserList = (process.env.INITIAL_AGENCY_EMAILS || '').split(
   /\s*,\s*/
-)
+).filter(_.identity)
 
 const unitTestUsers = [
   {


### PR DESCRIPTION
Sister PR to https://github.com/usdigitalresponse/usdr-gost/pull/310, this makes ARPA-side changes to allow ARPA tests to run in the GOST repo.

Namely:
- `SRC_DIR` is refactored into `SERVER_CODE_DIR` to remove dependency on a specific directory structure
  - its test is updated accordingly, as well as removing dynamic require which my import rewriter script cannot handle. I don't really see a strong reason it was like this before? Perhaps @ajhyndman or @igor47 have an idea?
- Add a seed for GOST's `tenants` table (no-ops in legacy ARPA repo)
- Modify `add-dummy-data` script to conditionally populate required `agencies.main_agency_id` column when running in GOST repo
- Modify test seeds for `roles` and `users` to support the GOST versions of those tables
- Adjust the regexes used in `requireSrc` to handle GOST's directory layout (also though about just replacing all of these with regular relative `require`s that could be handled by the import rewriter, but meh, there are a number of these)
- Test runner changes
  - Change where the `.env` file is found, conditionally
  - Handle environment variables whose name contains an `=` symbol correctly (e.g. `NODE_OPTIONS`)
  - Don't depend on specific directory structure when referencing tests and test seeds

There are still a few other things that need to be addressed to get tests to *pass*, notably adjusting the seed data like I did in my dev branch's https://github.com/usdigitalresponse/usdr-gost/pull/308/commits/b66ff2ff736306524b03d10b25ec08c7bd0f205f -- but I'm going to take a separate look at that in the context of other seed-related changes.