### PR TITLE
GOST integration: script to dump all relevant database tables and all uploaded files to a zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "mocha": "^9.2.1",
     "nodemon": "2.0.15",
     "prettier": "2.6.1",
+    "recursive-readdir-async": "^1.2.1",
     "sass": "1.52.1",
     "sass-loader": "13.0.0",
     "standard": "^16.0.3",

--- a/scripts/dump_data.js
+++ b/scripts/dump_data.js
@@ -1,0 +1,119 @@
+const _ = require("lodash");
+const AdmZip = require("adm-zip");
+const fs = require("fs/promises");
+const inquirer = require("inquirer");
+const path = require("path");
+
+const knex = require("../src/server/db/connection");
+const { uploadFSName } = require("../src/server/services/persist-upload");
+const { periodTemplatePath } = require("../src/server/services/get-template");
+
+const TABLES = [
+  "users",
+  "agencies",
+  "reporting_periods",
+  "uploads", // has FK to reporting_periods
+  "arpa_subrecipients", // has FK to uploads
+  "application_settings", // has FK to reporting_periods
+  "projects", // has FK to reporting_periods
+  "period_summaries", // has FK to reporting_periods, projects
+];
+
+async function getDatabaseContents() {
+  console.log("Fetching all DB rows...");
+  const start = Date.now();
+
+  const data = await Promise.all(
+    TABLES.map((tableName) => knex(tableName).select("*"))
+  );
+  const ret = _.fromPairs(_.zip(TABLES, data));
+
+  const end = Date.now();
+  console.log("Fetching DB rows took", end - start, "ms");
+
+  return ret;
+}
+
+function getAllFilePaths(dbContents) {
+  const { uploads, reporting_periods } = dbContents;
+
+  return [
+    ...uploads.map((upload) => uploadFSName(upload)),
+    ...reporting_periods
+      .filter((rp) => rp.template_filename)
+      .map((rp) => periodTemplatePath(rp)),
+  ];
+}
+
+function addFilesToZip(dbContents, zipFile) {
+  const filePaths = getAllFilePaths(dbContents);
+  console.log('Adding', filePaths.length, 'uploaded files to zip output...');
+  const start = Date.now();
+
+  // Sanity check: all filenames should be unique since they will all be together
+  // in the zip
+  const fnames = filePaths.map((filePath) => path.basename(filePath));
+  const dupeFilenames = _.chain(fnames)
+    .groupBy(_.identity)
+    .pickBy((v) => v.length > 1)
+    .keys()
+    .value();
+  if (dupeFilenames.length > 0) {
+    console.error("Duplicate filenames:", dupeFilenames);
+    throw new Error("duplicate filenames cannot be added to zip!");
+  }
+
+  for (const filePath of filePaths) {
+    zipFile.addLocalFile(filePath, path.join('files', path.basename(filePath)));
+  }
+
+  // Sanity check: look for files in upload directory not captured by the above
+  // TODO
+
+  const end = Date.now();
+  console.log('Took', end-start, 'ms to add uploads to zip');
+}
+
+function writeZip(zipFile, outputFilename) {
+  console.log('Writing zip file...');
+  const start = Date.now();
+
+  zipFile.writeZip(outputFilename);
+
+  const end = Date.now();
+  console.log('Took', end-start, 'ms to write zip file');
+}
+
+async function main() {
+  const dateStr = new Date()
+    .toISOString()
+    .replace(/[^0-9]/g, "")
+    .substring(0, 14);
+  const defaultOutputFilename = `/tmp/arpa-reporter-dump-${dateStr}.zip`;
+  const { outputFilename } = await inquirer.prompt([
+    {
+      type: "input",
+      name: "outputFilename",
+      message: "Output filename:",
+      default: defaultOutputFilename,
+    },
+  ]);
+  const zipFile = new AdmZip();
+
+  // Get db contents
+  const dbContents = await getDatabaseContents();
+  zipFile.addFile("sql.json", Buffer.from(JSON.stringify(dbContents), "utf8"));
+
+  // Copy files to zip
+  addFilesToZip(dbContents, zipFile);
+
+  // Generate the zip file
+  writeZip(zipFile, outputFilename);
+  const { size: outputSize } = await fs.stat(outputFilename);
+  console.log("Wrote", outputSize, "bytes to", outputFilename);
+  console.log("File is unencrypted, be sure to delete after transferring.");
+}
+
+if (require.main === module) {
+  main().then(() => process.exit());
+}

--- a/scripts/dump_data.js
+++ b/scripts/dump_data.js
@@ -70,12 +70,15 @@ async function addFilesToZip(dbContents, zipFile) {
     .keys()
     .value();
   if (dupeFilenames.length > 0) {
-    console.error("ERROR: duplicate filenames, will be overwritten in zip:", dupeFilenames);
+    console.error(
+      "ERROR: duplicate filenames, will be overwritten in zip:",
+      dupeFilenames
+    );
   }
 
   for (const filePath of pathsToCopy) {
     const pathInZip = path.join("files", path.basename(filePath));
-    console.log('Adding', filePath, 'to zip at', pathInZip);
+    console.log("Adding", filePath, "to zip at", pathInZip);
     zipFile.addLocalFile(filePath, pathInZip);
   }
 
@@ -100,6 +103,17 @@ function writeZip(zipFile, outputFilename) {
 
   const end = Date.now();
   console.log("Took", end - start, "ms to write zip file");
+}
+
+function getAllTenantIds(dbContents) {
+  return _.chain(dbContents)
+    .values()
+    .flatten()
+    .map("tenant_id")
+    .uniq()
+    .filter((x) => x !== undefined)
+    .sort()
+    .value();
 }
 
 async function main() {
@@ -134,6 +148,7 @@ async function main() {
     runDate,
     outputPath: outputFilename,
     numRows: _.mapValues(dbContents, (v) => v.length),
+    tenantIds: getAllTenantIds(dbContents),
     ...addFilesDebugInfo,
   };
   zipFile.addFile(

--- a/scripts/dump_data.js
+++ b/scripts/dump_data.js
@@ -3,10 +3,12 @@ const AdmZip = require("adm-zip");
 const fs = require("fs/promises");
 const inquirer = require("inquirer");
 const path = require("path");
+const { list: listFiles } = require("recursive-readdir-async");
 
 const knex = require("../src/server/db/connection");
 const { uploadFSName } = require("../src/server/services/persist-upload");
 const { periodTemplatePath } = require("../src/server/services/get-template");
+const { UPLOAD_DIR } = require("../src/server/environment");
 
 const TABLES = [
   "users",
@@ -34,7 +36,7 @@ async function getDatabaseContents() {
   return ret;
 }
 
-function getAllFilePaths(dbContents) {
+function getAllFilesToCopy(dbContents) {
   const { uploads, reporting_periods } = dbContents;
 
   return [
@@ -45,47 +47,63 @@ function getAllFilePaths(dbContents) {
   ];
 }
 
-function addFilesToZip(dbContents, zipFile) {
-  const filePaths = getAllFilePaths(dbContents);
-  console.log('Adding', filePaths.length, 'uploaded files to zip output...');
+async function getAllFilesInUploadDir() {
+  const files = await listFiles(UPLOAD_DIR, {
+    recursive: true,
+    ignoreFolders: true,
+  });
+
+  return files.map((f) => f.fullname);
+}
+
+async function addFilesToZip(dbContents, zipFile) {
+  const pathsToCopy = getAllFilesToCopy(dbContents);
+  console.log("Adding", pathsToCopy.length, "uploaded files to zip output...");
   const start = Date.now();
 
   // Sanity check: all filenames should be unique since they will all be together
   // in the zip
-  const fnames = filePaths.map((filePath) => path.basename(filePath));
+  const fnames = pathsToCopy.map((filePath) => path.basename(filePath));
   const dupeFilenames = _.chain(fnames)
     .groupBy(_.identity)
     .pickBy((v) => v.length > 1)
     .keys()
     .value();
   if (dupeFilenames.length > 0) {
-    console.error("Duplicate filenames:", dupeFilenames);
-    throw new Error("duplicate filenames cannot be added to zip!");
+    console.error("ERROR: duplicate filenames:", dupeFilenames);
   }
 
-  for (const filePath of filePaths) {
-    zipFile.addLocalFile(filePath, path.join('files', path.basename(filePath)));
+  for (const filePath of pathsToCopy) {
+    zipFile.addLocalFile(filePath, path.join("files", path.basename(filePath)));
   }
 
   // Sanity check: look for files in upload directory not captured by the above
   // TODO
+  const allUploadPaths = await getAllFilesInUploadDir();
+  const missedFiles = _.difference(allUploadPaths, pathsToCopy);
+  if (missedFiles.length) {
+    console.warn("WARN: some files in upload dir not captured:", missedFiles);
+  }
 
   const end = Date.now();
-  console.log('Took', end-start, 'ms to add uploads to zip');
+  console.log("Took", end - start, "ms to add uploads to zip");
+
+  return { pathsToCopy, dupeFilenames, missedFiles };
 }
 
 function writeZip(zipFile, outputFilename) {
-  console.log('Writing zip file...');
+  console.log("Writing zip file...");
   const start = Date.now();
 
   zipFile.writeZip(outputFilename);
 
   const end = Date.now();
-  console.log('Took', end-start, 'ms to write zip file');
+  console.log("Took", end - start, "ms to write zip file");
 }
 
 async function main() {
-  const dateStr = new Date()
+  const runDate = new Date();
+  const dateStr = runDate
     .toISOString()
     .replace(/[^0-9]/g, "")
     .substring(0, 14);
@@ -102,10 +120,25 @@ async function main() {
 
   // Get db contents
   const dbContents = await getDatabaseContents();
-  zipFile.addFile("sql.json", Buffer.from(JSON.stringify(dbContents), "utf8"));
+  zipFile.addFile(
+    "sql.json",
+    Buffer.from(JSON.stringify(dbContents, undefined, 2), "utf8")
+  );
 
   // Copy files to zip
-  addFilesToZip(dbContents, zipFile);
+  const addFilesDebugInfo = await addFilesToZip(dbContents, zipFile);
+
+  // Collect some debug information
+  const debug = {
+    runDate,
+    outputPath: outputFilename,
+    numRows: _.mapValues(dbContents, (v) => v.length),
+    ...addFilesDebugInfo,
+  };
+  zipFile.addFile(
+    "debug.json",
+    Buffer.from(JSON.stringify(debug, undefined, 2), "utf8")
+  );
 
   // Generate the zip file
   writeZip(zipFile, outputFilename);

--- a/scripts/dump_data.js
+++ b/scripts/dump_data.js
@@ -70,15 +70,16 @@ async function addFilesToZip(dbContents, zipFile) {
     .keys()
     .value();
   if (dupeFilenames.length > 0) {
-    console.error("ERROR: duplicate filenames:", dupeFilenames);
+    console.error("ERROR: duplicate filenames, will be overwritten in zip:", dupeFilenames);
   }
 
   for (const filePath of pathsToCopy) {
-    zipFile.addLocalFile(filePath, path.join("files", path.basename(filePath)));
+    const pathInZip = path.join("files", path.basename(filePath));
+    console.log('Adding', filePath, 'to zip at', pathInZip);
+    zipFile.addLocalFile(filePath, pathInZip);
   }
 
   // Sanity check: look for files in upload directory not captured by the above
-  // TODO
   const allUploadPaths = await getAllFilesInUploadDir();
   const missedFiles = _.difference(allUploadPaths, pathsToCopy);
   if (missedFiles.length) {

--- a/scripts/dump_data.js
+++ b/scripts/dump_data.js
@@ -63,8 +63,8 @@ async function addFilesToZip(dbContents, zipFile) {
 
   // Sanity check: all filenames should be unique since they will all be together
   // in the zip
-  const fnames = pathsToCopy.map((filePath) => path.basename(filePath));
-  const dupeFilenames = _.chain(fnames)
+  const dupeFilenames = _.chain(pathsToCopy)
+    .map(filePath => path.basename(filePath))
     .groupBy(_.identity)
     .pickBy((v) => v.length > 1)
     .keys()
@@ -77,9 +77,8 @@ async function addFilesToZip(dbContents, zipFile) {
   }
 
   for (const filePath of pathsToCopy) {
-    const pathInZip = path.join("files", path.basename(filePath));
-    console.log("Adding", filePath, "to zip at", pathInZip);
-    zipFile.addLocalFile(filePath, pathInZip);
+    const basename = path.basename(filePath);
+    zipFile.addLocalFile(filePath, 'files', basename);
   }
 
   // Sanity check: look for files in upload directory not captured by the above

--- a/src/server/routes/reporting-periods.js
+++ b/src/server/routes/reporting-periods.js
@@ -26,6 +26,7 @@ const {
   templateForPeriod
 } = require('../services/get-template')
 const { usedForTreasuryExport } = require('../db/uploads')
+const { ensureAsyncContext } = require('../lib/ensure-async-context')
 
 const { revalidateUploads } = require('../services/revalidate-uploads')
 
@@ -80,7 +81,7 @@ router.post('/', requireAdminUser, async function (req, res, next) {
 router.post(
   '/:id/template',
   requireAdminUser,
-  multerUpload.single('template'),
+  ensureAsyncContext(multerUpload.single('template')),
   async (req, res, next) => {
     if (!req.file) {
       res.status(400).json({ error: 'File missing' })

--- a/src/server/services/get-template.js
+++ b/src/server/services/get-template.js
@@ -17,6 +17,10 @@ module.exports = {
   savePeriodTemplate
 }
 
+// WARNING: changes to this function must be made with care, because:
+//  1. there may be existing data on disk with filenames set according to this function,
+//     which could become inaccessible
+//  2. this function is duplicated in GOST's import_arpa_reporter_dump.js script
 function periodTemplatePath (reportingPeriod) {
   return path.join(
     PERIOD_TEMPLATES_DIR,

--- a/src/server/services/get-template.js
+++ b/src/server/services/get-template.js
@@ -13,6 +13,7 @@ const treasuryTemplates = new Map()
 module.exports = {
   getTemplate,
   templateForPeriod,
+  periodTemplatePath,
   savePeriodTemplate
 }
 

--- a/src/server/services/persist-upload.js
+++ b/src/server/services/persist-upload.js
@@ -10,6 +10,10 @@ const { createUpload } = require('../db/uploads')
 const { UPLOAD_DIR } = require('../environment')
 const ValidationError = require('../lib/validation-error')
 
+// WARNING: changes to this function must be made with care, because:
+//  1. there may be existing data on disk with filenames set according to this function,
+//     which could become inaccessible
+//  2. this function is duplicated in GOST's import_arpa_reporter_dump.js script
 const uploadFSName = (upload) => {
   const filename = `${upload.id}${path.extname(upload.filename)}`
   return path.join(UPLOAD_DIR, filename)

--- a/src/server/services/persist-upload.js
+++ b/src/server/services/persist-upload.js
@@ -56,5 +56,6 @@ async function bufferForUpload (upload) {
 
 module.exports = {
   persistUpload,
-  bufferForUpload
+  bufferForUpload,
+  uploadFSName
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10240,6 +10240,11 @@ rechoir@^0.8.0:
   dependencies:
     resolve "^1.20.0"
 
+recursive-readdir-async@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/recursive-readdir-async/-/recursive-readdir-async-1.2.1.tgz#994beaa07a985e806a5946b4b795fe9b5f1a6b9b"
+  integrity sha512-fU8aySmHIhrycTlXn+hI7dS/p7GnrMHzr2xDdBSd8HZ16mbLkmfIEccIE80gLHftrkTt9oDJiGEJNIPY6n0v6A==
+
 redeyed@~2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-2.1.1.tgz#8984b5815d99cb220469c99eeeffe38913e6cc0b"


### PR DESCRIPTION
This is one part of what will be used to migrate existing partners with their own Render instances to a unified ARPA-Reporter-in-GOST world. The idea is that you'd:
1. run this script on their ARPA instance
2. temporarily enable SSH on both the ARPA instance and GOST prod instance
3. scp/rsync the file from ARPA to GOST
4. disable SSH
5. run a corresponding import script on the GOST side (implemented in https://github.com/usdigitalresponse/usdr-gost/pull/312)
6. delete the zip files on both sides

One concern about this script is that `adm-zip` reads the contents of all uploaded files into memory before writing the output zip. I'm not sure how many/how big uploads are practically dealing with, though I'm guessing this probably won't be a big issue?

There is also one minor drive-by fix in this PR: adding `ensureAsyncContext` around the template upload endpoint's `multer` middleware -- this was needed in order to test that the script correctly picked up uploaded templates (and indeed without this fix, uploading custom templates is currently broken since #473)