### PR TITLE
GOST Integration: populate redirect_to field during login

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -124,8 +124,12 @@ function loggedIn () {
 router.beforeEach((to, from, next) => {
   if (to.matched.some(record => record.meta.requiresLogin)) {
     if (!loggedIn()) {
+      // This will include any router base URL, if configured
+      const redirectTo = router.resolve(to.fullPath).href
+
       next({
-        path: '/login'
+        path: '/login',
+        query: { redirect_to: redirectTo }
       })
     } else {
       next()

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -48,8 +48,17 @@ export default {
         this.messageClass = 'alert alert-danger'
         return
       }
+
+      const redirectTo =
+        // If we got to the login page via a redirect, a post-login redirect URL will already be specified
+        this.$route.query.redirect_to ||
+        // If we went to the login page directly, we default to redirecting to the homepage.
+        // This gets a full relative URL including any VueRouter base prefix, if configured (such as in GOST)
+        this.$router.resolve('/').href
+
       const body = JSON.stringify({
-        email: this.email
+        email: this.email,
+        redirect_to: redirectTo
       })
       const headers = {
         'Content-Type': 'application/json'


### PR DESCRIPTION
We set a new URL param, `redirect_to` when redirecting to the login page from another VueRouter route, and the login page forwards that to its `/api/sessions` call.

In standalone ARPA Reporter repo, this parameter is ignored. But in GOST once https://github.com/usdigitalresponse/usdr-gost/pull/288 is merged, it will cause the login link email that's sent to also include a `redirect_to` field. In this way, after logging in using the GOST `/api/sessions` endpoints, the user is redirected back to ARPA Reporter rather than going to the GOST/ID Tool dashboard.

The VueRouter APIs used here automatically account for the `base` config option that will be set in GOST to nest the ARPA Reporter app under a URL path.