### PR TITLE
Display reporting period name, not id

### DIFF
--- a/src/views/Upload.vue
+++ b/src/views/Upload.vue
@@ -52,7 +52,7 @@
 
           <li class="list-group-item">
             <span class="font-weight-bold">Reporting Period: </span>
-            {{ upload.reporting_period_id }}
+            {{ reportingPeriodName }}
           </li>
 
           <li class="list-group-item" :class="{ 'list-group-item-warning': !upload.agency_id }">
@@ -95,7 +95,7 @@
           <span class="text-primary bg-light">{{ upload.agency_code }}</span>
           EC Code
           <span class="text-primary bg-light">{{ upload.ec_code }}</span>
-          in period {{ upload.reporting_period_id }}
+          in period {{ reportingPeriodName }}
         </h4>
 
         <template v-if="seriesExported">
@@ -196,6 +196,10 @@ export default {
         'list-group-item-success': this.upload.validated_at,
         'list-group-item-warning': !this.upload.validated_at
       }
+    },
+    reportingPeriodName: function () {
+      const reportingPeriod = this.$store.state.reportingPeriods.find(per => per.id === this.upload.reporting_period_id)
+      return reportingPeriod ? reportingPeriod.name : `ID: ${this.upload.reporting_period_id}`
     }
   },
   methods: {


### PR DESCRIPTION
Updates the upload screen to use the reporting period name instead of the id in the. two places it is dipslayed. This will become a bigger concern as we lean in to multi-tenancy in the GOST repo and period ids will be significantly higher than they currently are.

Old screenshot (says "period 1" in the rows of the left column, and the title of the right column)
<img width="1203" alt="Screen Shot 2022-09-13 at 1 22 33 PM" src="https://user-images.githubusercontent.com/3675290/190001909-45d7a117-4e8c-40a7-b1c0-31d10a2bb693.png">

Replaced both instances in this updated screenshot
<img width="1183" alt="Screen Shot 2022-09-13 at 1 21 34 PM" src="https://user-images.githubusercontent.com/3675290/190001971-408915bc-1a1c-46e3-91fa-1c02165aa2b2.png">
